### PR TITLE
Update github action workflow targets

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,5 +1,10 @@
 name: Cancel
-on: [push, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
 jobs:
   cancel:
     name: 'Cancel Previous Runs'

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,5 +1,9 @@
 name: Code Analysis
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   pana_analyze:

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,5 +1,9 @@
 name: Documentation Analysis
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   dartdoc_analysis:

--- a/.github/workflows/example_integration_test.yml
+++ b/.github/workflows/example_integration_test.yml
@@ -1,5 +1,10 @@
 name: Integration Tests
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   # chrome_integration_test:

--- a/.github/workflows/package_unit_test.yml
+++ b/.github/workflows/package_unit_test.yml
@@ -1,5 +1,9 @@
 name: Unit Tests
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   unit_test:


### PR DESCRIPTION
* Add branch modifier to all workflow targets
* Run workflows only when pushed to main branch
Reason - Tests would run twice on PR, once triggered by push and again triggered by the PR

## Before

Tests would run twice on every push to a PR

## After

Tests, on PR, are only triggered by the `pull_request`

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

- [x] No, this isn't a breaking change.
- [ ] Yes, this is a breaking change.
       I have modified or deleted the following public APIs in such a way that the package user has to make changes in their code to upgrade to the new version - 
  1. ...
  2. ...
  3. ...
