### PR TITLE
Add web cache support - v0.1.0

### DIFF
--- a/example/lib/constants.dart
+++ b/example/lib/constants.dart
@@ -12,15 +12,15 @@ const String firaSans = 'FiraSans';
 // Font source urls
 
 const String notoSansUrl =
-    'https://cdn.statically.io/gh/googlefonts/noto-fonts/v20201206-phase3/hinted/ttf/NotoSans/NotoSans-Regular.ttf';
+    'https://cdn.jsdelivr.net/gh/googlefonts/noto-fonts@v20201206-phase3/hinted/ttf/NotoSans/NotoSans-Regular.ttf';
 const String cascadiaCodeUrl =
-    'https://cdn.statically.io/gh/ryanoasis/nerd-fonts/v2.1.0/patched-fonts/CascadiaCode/complete/Caskaydia%20Cove%20Nerd%20Font%20Complete%20Mono.ttf';
+    'https://cdn.jsdelivr.net/gh/ryanoasis/nerd-fonts@v2.1.0/patched-fonts/CascadiaCode/complete/Caskaydia%20Cove%20Nerd%20Font%20Complete%20Mono.ttf';
 const String firaMonoUrl =
-    'https://cdn.statically.io/gh/mozilla/Fira/4.202/ttf/FiraMono-Regular.ttf';
+    'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraMono-Regular.ttf';
 
 const String firaSansBoldUrl =
-        'https://cdn.statically.io/gh/mozilla/Fira/4.202/ttf/FiraSans-Bold.ttf',
-    firaSansRegularUrl = 'https://cdn.statically.io/gh/mozilla/Fira/4.202/ttf/FiraSans-Regular.ttf',
-    firaSansItalicUrl = 'https://cdn.statically.io/gh/mozilla/Fira/4.202/ttf/FiraSans-Italic.ttf',
-    firaSansThinUrl = 'https://cdn.statically.io/gh/mozilla/Fira/4.202/ttf/FiraSans-Thin.ttf';
+        'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Bold.ttf',
+    firaSansRegularUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Regular.ttf',
+    firaSansItalicUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Italic.ttf',
+    firaSansThinUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Thin.ttf';
 const String firaCodeUrl = String.fromEnvironment('FIREBASE_STORAGE_FONT_URL');

--- a/example/lib/src/demos/download_use_delete_demo.dart
+++ b/example/lib/src/demos/download_use_delete_demo.dart
@@ -64,7 +64,6 @@ class _DynamicCachedFontsDemo3State extends State<DynamicCachedFontsDemo3> {
       DynamicCachedFonts.cacheFont(notoSansUrl, verboseLog: true);
 
   Future<void> handleUseFontPress() async {
-
     if (await DynamicCachedFonts.canLoadFont(notoSansUrl, verboseLog: true)) {
       await DynamicCachedFonts.loadCachedFont(notoSansUrl, fontFamily: notoSans, verboseLog: true);
       setState(() {});

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -340,7 +340,7 @@ class DynamicCachedFonts {
       <String>[
         'Font has been downloaded!\n',
         'Font file path - ${font.path}',
-        (await font.stat()).toString(),
+        font.statSync().toString(),
       ],
       verboseLog: _verboseLog,
     );

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -350,7 +350,7 @@ class DynamicCachedFonts {
     return ByteData.view(fontBytes.buffer);
   }
 
-  /// Caches the [url] with the given configuration.
+  /// Downloads and caches font from the [url] with the given configuration.
   ///
   /// - **REQUIRED** The [url] property is used to specify the download url
   ///   for the required font. It should be a valid http/https url which points to

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -322,7 +322,7 @@ class DynamicCachedFonts {
   Future<ByteData> _handleCache(String url) async {
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final Config cacheconfig = Config(
+    final Config cacheConfig = Config(
       cacheKey,
       stalePeriod: cacheStalePeriod,
       maxNrOfCacheObjects: maxCacheObjects,
@@ -331,7 +331,7 @@ class DynamicCachedFonts {
     final String downloadUrl =
         _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url;
 
-    final File font = await CacheManager(cacheconfig).getSingleFile(
+    final File font = await CacheManager(cacheConfig).getSingleFile(
       downloadUrl,
       key: cacheKey,
     );

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -12,7 +12,7 @@ import 'package:flutter/widgets.dart'
 import 'package:flutter_cache_manager/flutter_cache_manager.dart' show CacheManager, Config;
 
 import 'src/raw_dynamic_cached_fonts.dart' show RawDynamicCachedFonts;
-import 'src/utils.dart' show Utils, devLog;
+import 'src/utils.dart';
 
 export 'src/raw_dynamic_cached_fonts.dart';
 
@@ -100,8 +100,8 @@ class DynamicCachedFonts {
   DynamicCachedFonts({
     @required String url,
     @required this.fontFamily,
-    this.maxCacheObjects = 200,
-    this.cacheStalePeriod = const Duration(days: 365),
+    this.maxCacheObjects = kDefaultMaxCacheObjects,
+    this.cacheStalePeriod = kDefaultCacheStalePeriod,
     bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
@@ -155,8 +155,8 @@ class DynamicCachedFonts {
   DynamicCachedFonts.family({
     @required this.urls,
     @required this.fontFamily,
-    this.maxCacheObjects = 200,
-    this.cacheStalePeriod = const Duration(days: 365),
+    this.maxCacheObjects = kDefaultMaxCacheObjects,
+    this.cacheStalePeriod = kDefaultCacheStalePeriod,
     bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
@@ -215,8 +215,8 @@ class DynamicCachedFonts {
   DynamicCachedFonts.fromFirebase({
     @required String bucketUrl,
     @required this.fontFamily,
-    this.maxCacheObjects = 200,
-    this.cacheStalePeriod = const Duration(days: 365),
+    this.maxCacheObjects = kDefaultMaxCacheObjects,
+    this.cacheStalePeriod = kDefaultCacheStalePeriod,
     bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
@@ -322,16 +322,12 @@ class DynamicCachedFonts {
   Future<ByteData> _handleCache(String url) async {
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final Config cacheConfig = Config(
-      cacheKey,
-      stalePeriod: cacheStalePeriod,
-      maxNrOfCacheObjects: maxCacheObjects,
-    );
+    handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
 
     final String downloadUrl =
         _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url;
 
-    final File font = await CacheManager(cacheConfig).getSingleFile(
+    final File font = await getCacheManager(cacheKey).getSingleFile(
       downloadUrl,
       key: cacheKey,
     );
@@ -381,8 +377,8 @@ class DynamicCachedFonts {
   ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<void> cacheFont(
     String url, {
-    Duration cacheStalePeriod = const Duration(days: 365),
-    int maxCacheObjects = 200,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
     bool verboseLog = false,
   }) =>
       RawDynamicCachedFonts.cacheFont(

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data' show ByteData, Uint8List;
 
-import 'package:flutter/foundation.dart' show FlutterError, kIsWeb, kReleaseMode, required;
+import 'package:flutter/foundation.dart' show kReleaseMode, required, FlutterError;
 import 'package:flutter/services.dart' show FontLoader;
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding, TextStyle;
 import 'package:flutter_cache_manager/flutter_cache_manager.dart'
@@ -119,7 +119,7 @@ abstract class RawDynamicCachedFonts {
         verboseLog: verboseLog,
       );
     }
-    return font != null || kIsWeb;
+    return font != null;
   }
 
   /// Fetches the given [url] from cache and loads it as an asset.
@@ -150,19 +150,10 @@ abstract class RawDynamicCachedFonts {
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
-    final CacheManager cacheManager = CacheManager(Config(cacheKey));
 
-    final FileInfo font = await cacheManager.getFileFromCache(cacheKey);
+    final FileInfo font = await CacheManager(Config(cacheKey)).getFileFromCache(cacheKey);
 
-    // TODO: Find a better implementation
-    // getFileFromCache throws exceptions on web
-    final Uint8List fontBytes = !kIsWeb
-        ? await font.file.readAsBytes()
-        : await (await cacheManager.getSingleFile(
-            url,
-            key: cacheKey,
-          ))
-            .readAsBytes();
+    final Uint8List fontBytes = await font.file.readAsBytes();
 
     final ByteData cachedFontBytes = ByteData.view(fontBytes.buffer);
 
@@ -213,19 +204,10 @@ abstract class RawDynamicCachedFonts {
 
     final Iterable<Future<ByteData>> cachedFontBytes = urls.map((String url) async {
       final String cacheKey = Utils.sanitizeUrl(url);
-      final CacheManager cacheManager = CacheManager(Config(cacheKey));
 
-      final FileInfo font = await cacheManager.getFileFromCache(cacheKey);
+      final FileInfo font = await CacheManager(Config(cacheKey)).getFileFromCache(cacheKey);
 
-      // TODO: Find a better implementation
-      // getFileFromCache throws exceptions on web
-      final Uint8List fontBytes = !kIsWeb
-          ? await font.file.readAsBytes()
-          : await (await cacheManager.getSingleFile(
-              url,
-              key: cacheKey,
-            ))
-              .readAsBytes();
+      final Uint8List fontBytes = await font.file.readAsBytes();
 
       return ByteData.view(fontBytes.buffer);
     });

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -13,7 +13,9 @@ import 'utils.dart';
 ///
 /// [DynamicCachedFonts] is a concrete implementation of this class.
 abstract class RawDynamicCachedFonts {
-  /// Caches the [url] with the given configuration.
+  const RawDynamicCachedFonts._();
+
+  /// Downloads and caches font from the [url] with the given configuration.
   ///
   /// - **REQUIRED** The [url] property is used to specify the download url
   ///   for the required font. It should be a valid http/https url which points to

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -57,12 +57,9 @@ abstract class RawDynamicCachedFonts {
     }
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final Config cacheconfig = Config(
-      cacheKey,
-      stalePeriod: cacheStalePeriod,
-      maxNrOfCacheObjects: maxCacheObjects,
-    );
-    final FileInfo font = await CacheManager(cacheconfig).downloadFile(
+    handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
+
+    final FileInfo font = await getCacheManager(cacheKey).downloadFile(
       url,
       key: cacheKey,
     );
@@ -104,7 +101,7 @@ abstract class RawDynamicCachedFonts {
     // Try catch to catch any errors thrown by the cache manager
     // or the assertion.
     try {
-      font = await CacheManager(Config(cacheKey)).getFileFromCache(cacheKey);
+      font = await getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
       assert(
         font != null,
@@ -151,7 +148,7 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final FileInfo font = await CacheManager(Config(cacheKey)).getFileFromCache(cacheKey);
+    final FileInfo font = await getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
     final Uint8List fontBytes = await font.file.readAsBytes();
 
@@ -209,7 +206,7 @@ abstract class RawDynamicCachedFonts {
     final Iterable<Future<ByteData>> cachedFontBytes = urls.map((String url) async {
       final String cacheKey = Utils.sanitizeUrl(url);
 
-      final FileInfo font = await CacheManager(Config(cacheKey)).getFileFromCache(cacheKey);
+      final FileInfo font = await getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
       final Uint8List fontBytes = await font.file.readAsBytes();
 
@@ -241,6 +238,6 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    return CacheManager(Config(cacheKey)).removeFile(cacheKey);
+    return getCacheManager(cacheKey).removeFile(cacheKey);
   }
 }

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -165,7 +165,11 @@ abstract class RawDynamicCachedFonts {
     await fontLoader.load();
 
     devLog(
-      <String>['Font has been loaded!'],
+      <String>[
+        'Font has been loaded!',
+        'This font file is valid till - ${font.validTill}',
+        'File stat - ${font.file.statSync()}'
+      ],
       verboseLog: verboseLog,
     );
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -101,12 +101,10 @@ class Utils {
     } else {
       dev.log(
         'Bad File Format',
-        error: FlutterError(
-          <String>[
-            'The provided file format is not supported',
-            'Received file format: $fileFormat',
-          ].join('\n'),
-        ),
+        error: <String>[
+          'The provided file format is not supported',
+          'Received file format: $fileFormat',
+        ].join('\n'),
         name: kLoggerName,
       );
       return false;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,12 +1,18 @@
-// ignore_for_file: public_member_api_docs
 import 'dart:developer' as dev;
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart' show required;
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' show CacheManager, Config;
 
 /// The name for for [dev.log].
 const String kLoggerName = 'DynamicCachedFonts';
+
+/// The default cacheStalePeriod.
+const Duration kDefaultCacheStalePeriod = Duration(days: 365);
+
+/// The default maxCacheObjects.
+const int kDefaultMaxCacheObjects = 200;
 
 /// Logs a message to the console
 void devLog(List<String> messageList, {@required bool verboseLog}) {
@@ -15,6 +21,45 @@ void devLog(List<String> messageList, {@required bool verboseLog}) {
     dev.log(
       message,
       name: kLoggerName,
+    );
+  }
+}
+
+class DynamicCachedFontsCacheManager {
+  DynamicCachedFontsCacheManager._();
+
+  /// The default cache key for cache managers' configurations
+  static const String defaultCacheKey = 'DynamicCachedFontsFontCacheKey';
+
+  static Map<String, CacheManager> cacheManagers = <String, CacheManager>{};
+
+  static CacheManager get defaultCacheManager => cacheManagers[defaultCacheKey];
+
+  static set defaultCacheManager(CacheManager cacheManager) {
+    cacheManagers[defaultCacheKey] = cacheManager;
+  }
+}
+
+CacheManager getCacheManager(String cacheKey) =>
+    DynamicCachedFontsCacheManager.cacheManagers[cacheKey] ??
+    DynamicCachedFontsCacheManager.defaultCacheManager;
+
+void handleCacheManager(String cacheKey, Duration cacheStalePeriod, int maxCacheObjects) {
+  if (cacheStalePeriod == kDefaultCacheStalePeriod && maxCacheObjects == kDefaultMaxCacheObjects) {
+    DynamicCachedFontsCacheManager.defaultCacheManager ??= CacheManager(
+      Config(
+        DynamicCachedFontsCacheManager.defaultCacheKey,
+        stalePeriod: cacheStalePeriod,
+        maxNrOfCacheObjects: maxCacheObjects,
+      ),
+    );
+  } else {
+    DynamicCachedFontsCacheManager.cacheManagers[cacheKey] ??= CacheManager(
+      Config(
+        cacheKey,
+        stalePeriod: cacheStalePeriod,
+        maxNrOfCacheObjects: maxCacheObjects,
+      ),
     );
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -49,15 +49,18 @@ class DynamicCachedFontsCacheManager {
 
   /// A map of [CacheManager]s used throughout the package. The key used
   /// will correspond to [Config.cacheKey] of the respective [CacheManager].
-  static Map<String, CacheManager> cacheManagers = <String, CacheManager>{};
+  static Map<String, CacheManager> cacheManagers = <String, CacheManager>{
+    defaultCacheKey: CacheManager(
+      Config(
+        DynamicCachedFontsCacheManager.defaultCacheKey,
+        stalePeriod: kDefaultCacheStalePeriod,
+        maxNrOfCacheObjects: kDefaultMaxCacheObjects,
+      ),
+    ),
+  };
 
   /// The getter for the default instance of [CacheManager] in [cacheManagers].
   static CacheManager get defaultCacheManager => cacheManagers[defaultCacheKey];
-
-  /// The setter for the default instance of [CacheManager] in [cacheManagers].
-  static set defaultCacheManager(CacheManager cacheManager) {
-    cacheManagers[defaultCacheKey] = cacheManager;
-  }
 }
 
 /// Returns a custom [CacheManager], if present, or
@@ -67,15 +70,7 @@ CacheManager getCacheManager(String cacheKey) =>
 
 /// Creates a new instance of [CacheManager] if the default can't be used.
 void handleCacheManager(String cacheKey, Duration cacheStalePeriod, int maxCacheObjects) {
-  if (cacheStalePeriod == kDefaultCacheStalePeriod && maxCacheObjects == kDefaultMaxCacheObjects) {
-    DynamicCachedFontsCacheManager.defaultCacheManager ??= CacheManager(
-      Config(
-        DynamicCachedFontsCacheManager.defaultCacheKey,
-        stalePeriod: cacheStalePeriod,
-        maxNrOfCacheObjects: maxCacheObjects,
-      ),
-    );
-  } else {
+  if (cacheStalePeriod != kDefaultCacheStalePeriod && maxCacheObjects != kDefaultMaxCacheObjects) {
     DynamicCachedFontsCacheManager.cacheManagers[cacheKey] ??= CacheManager(
       Config(
         cacheKey,


### PR DESCRIPTION
* Improve formatting - example handle-use-delete demo
* When font is to be used, it is loaded from cache instead of being requested from the URL every time
* Improve logging in _DynamicCachedFonts.load_, _RawDynamicCachedFonts.loadCachedFont_ and while verifying font extensions 
* Disable RawDynamicCachedFonts constructor.
* Improve `cacheFont` comments
* Improve integration test performance. Migrate all links to fonts in example to use jsdelivr. 

## Related Issues

N/A

## Before

## After

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

- [x] No, this isn't a breaking change.
- [ ] Yes, this is a breaking change.
       I have modified or deleted the following public APIs in such a way that the package user has to make changes in their code to upgrade to the new version - 
  1. ...
  2. ...
  3. ...
