### PR TITLE
Make cacheManager required in .custom method

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -378,7 +378,7 @@ class DynamicCachedFonts {
   /// [CacheManager] used in [cacheManager].
   @visibleForTesting
   static void custom({
-    CacheManager cacheManager,
+    @required CacheManager cacheManager,
     bool force = false,
   }) =>
       RawDynamicCachedFonts.custom(


### PR DESCRIPTION
## Related Issues

N/A

## Before

`cacheManager` was not a required field.

## After

`cacheManager` is  a required field.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No, since the new API has not been released yet.

<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
