### PR TITLE
Expose cacheKey generator as a public API

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -16,6 +16,8 @@ import 'src/utils.dart';
 
 export 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
+export 'src/utils.dart' show cacheKeyFromUrl;
+
 part 'src/raw_dynamic_cached_fonts.dart';
 
 /// Allows dynamically loading fonts from the given url.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,12 @@ import 'dart:developer' as dev;
 
 import 'package:firebase_storage/firebase_storage.dart' show FirebaseStorage, Reference;
 import 'package:flutter_cache_manager/flutter_cache_manager.dart' show CacheManager, Config;
-import 'package:meta/meta.dart' show required, internal;
+import 'package:meta/meta.dart' show internal, required, visibleForTesting;
+
+/// Gets the sanitized url from [url] which is used as `cacheKey` when 
+/// downloading, caching or loading.
+@visibleForTesting
+String cacheKeyFromUrl(String url) => Utils.sanitizeUrl(url);
 
 /// The name for for [dev.log].
 @internal
@@ -70,7 +75,7 @@ class DynamicCachedFontsCacheManager {
   static CacheManager get customCacheManager => cacheManagers[_customCacheKey];
 
   /// The setter for the custom instance of [CacheManager] in [cacheManagers].
-  /// [Config.cacheKey] will be used as the key when adding the instance to 
+  /// [Config.cacheKey] will be used as the key when adding the instance to
   /// [cacheManagers].
   static set customCacheManager(CacheManager cacheManager) {
     _customCacheKey =


### PR DESCRIPTION
A part of testability enhancements (#14)

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
