### PR TITLE
Refactor `DynamicCachedFontsCacheManager`

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -335,12 +335,12 @@ class DynamicCachedFonts {
   Future<File> _handleCache(String url) async {
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    Utils.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
+    DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
 
     final String downloadUrl =
         _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url;
 
-    final File font = await Utils.getCacheManager(cacheKey).getSingleFile(
+    final File font = await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getSingleFile(
       downloadUrl,
       key: cacheKey,
     );

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -77,9 +77,10 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    Utils.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
+    DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
 
-    final FileInfo font = await Utils.getCacheManager(cacheKey).downloadFile(
+    final FileInfo font =
+        await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).downloadFile(
       url,
       key: cacheKey,
     );
@@ -129,7 +130,8 @@ abstract class RawDynamicCachedFonts {
     // Try catch to catch any errors thrown by the cache manager
     // or the assertion.
     try {
-      font = await Utils.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+      font =
+          await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
       assert(
         font != null,
@@ -176,7 +178,8 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final FileInfo font = await Utils.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+    final FileInfo font =
+        await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
     final Uint8List fontBytes = await font.file.readAsBytes();
 
@@ -237,7 +240,8 @@ abstract class RawDynamicCachedFonts {
       urls.map((String url) async {
         final String cacheKey = Utils.sanitizeUrl(url);
 
-        final FileInfo font = await Utils.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+        final FileInfo font = await DynamicCachedFontsCacheManager.getCacheManager(cacheKey)
+            .getFileFromCache(cacheKey);
 
         return font;
       }),
@@ -276,6 +280,6 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    await Utils.getCacheManager(cacheKey).removeFile(cacheKey);
+    await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).removeFile(cacheKey);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -85,6 +85,23 @@ class DynamicCachedFontsCacheManager {
         cacheManager.store.storeKey; // This is the same key provided to Config.cacheKey.
     _cacheManagers[_customCacheKey] = cacheManager;
   }
+
+  /// Returns a custom [CacheManager], if present, or
+  static CacheManager getCacheManager(String cacheKey) =>
+      customCacheManager ?? _cacheManagers[cacheKey] ?? defaultCacheManager;
+
+  /// Creates a new instance of [CacheManager] if the default can't be used.
+  static void handleCacheManager(String cacheKey, Duration cacheStalePeriod, int maxCacheObjects) {
+    if (cacheStalePeriod != kDefaultCacheStalePeriod ||
+        maxCacheObjects != kDefaultMaxCacheObjects) {
+      _cacheManagers[cacheKey] ??= CacheManager(
+        Config(
+          cacheKey,
+          stalePeriod: cacheStalePeriod,
+          maxNrOfCacheObjects: maxCacheObjects,
+        ),
+      );
+    }
   }
 }
 
@@ -179,24 +196,4 @@ class Utils {
   /// Remove `/` or `:` from url which can cause errors when used as storage paths
   /// in some operating systems.
   static String sanitizeUrl(String url) => url.replaceAll(RegExp(r'\/|:'), '');
-
-  /// Returns a custom [CacheManager], if present, or
-  static CacheManager getCacheManager(String cacheKey) =>
-      DynamicCachedFontsCacheManager.customCacheManager ??
-      DynamicCachedFontsCacheManager.cacheManagers[cacheKey] ??
-      DynamicCachedFontsCacheManager.defaultCacheManager;
-
-  /// Creates a new instance of [CacheManager] if the default can't be used.
-  static void handleCacheManager(String cacheKey, Duration cacheStalePeriod, int maxCacheObjects) {
-    if (cacheStalePeriod != kDefaultCacheStalePeriod ||
-        maxCacheObjects != kDefaultMaxCacheObjects) {
-      DynamicCachedFontsCacheManager.cacheManagers[cacheKey] ??= CacheManager(
-        Config(
-          cacheKey,
-          stalePeriod: cacheStalePeriod,
-          maxNrOfCacheObjects: maxCacheObjects,
-        ),
-      );
-    }
-  }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -40,50 +40,51 @@ void devLog(List<String> messageList, {@required bool verboseLog}) {
 ///
 /// When `cacheStalePeriod` or `maxCacheObjects` is not modified, a default instance
 /// of [CacheManager] is created when a font cache/load is requested. This instance
-/// assigns [defaultCacheKey] to [Config.cacheKey], [kDefaultCacheStalePeriod]
+/// assigns [_defaultCacheKey] to [Config.cacheKey], [kDefaultCacheStalePeriod]
 /// to [Config.stalePeriod] and [kDefaultMaxCacheObjects] to [Config.maxNrOfCacheObjects].
-/// The instance is added to [cacheManagers] with [defaultCacheKey] as the key.
+/// The instance is added to [_cacheManagers] with [_defaultCacheKey] as the key.
 ///
 /// The default instance can be easily accessed with [defaultCacheManager].
 ///
 /// When caching/loading a font, if `cacheStalePeriod` or `maxCacheObjects` is modified
-/// by the caller, a new instance of [CacheManager] is created and added to [cacheManagers].
+/// by the caller, a new instance of [CacheManager] is created and added to [_cacheManagers].
 /// This instance uses the sanitized url (see [Utils.sanitizeUrl]) as [Config.cacheKey] and
-/// as the key when adding the instance to [cacheManagers].
+/// as the key when adding the instance to [_cacheManagers].
 @internal
 class DynamicCachedFontsCacheManager {
   DynamicCachedFontsCacheManager._();
 
   /// The default cache key for cache managers' configurations
-  static const String defaultCacheKey = 'DynamicCachedFontsFontCacheKey';
+  static const String _defaultCacheKey = 'DynamicCachedFontsFontCacheKey';
 
   /// A map of [CacheManager]s used throughout the package. The key used
   /// will correspond to [Config.cacheKey] of the respective [CacheManager].
-  static Map<String, CacheManager> cacheManagers = <String, CacheManager>{
-    defaultCacheKey: CacheManager(
+  static final Map<String, CacheManager> _cacheManagers = <String, CacheManager>{
+    _defaultCacheKey: CacheManager(
       Config(
-        DynamicCachedFontsCacheManager.defaultCacheKey,
+        _defaultCacheKey,
         stalePeriod: kDefaultCacheStalePeriod,
         maxNrOfCacheObjects: kDefaultMaxCacheObjects,
       ),
     ),
   };
 
-  /// The getter for the default instance of [CacheManager] in [cacheManagers].
-  static CacheManager get defaultCacheManager => cacheManagers[defaultCacheKey];
-
   static String _customCacheKey;
 
-  /// The getter for the custom instance of [CacheManager] in [cacheManagers].
-  static CacheManager get customCacheManager => cacheManagers[_customCacheKey];
+  /// The getter for the default instance of [CacheManager] in [_cacheManagers].
+  static CacheManager get defaultCacheManager => _cacheManagers[_defaultCacheKey];
 
-  /// The setter for the custom instance of [CacheManager] in [cacheManagers].
+  /// The getter for the custom instance of [CacheManager] in [_cacheManagers].
+  static CacheManager get customCacheManager => _cacheManagers[_customCacheKey];
+
+  /// The setter for the custom instance of [CacheManager] in [_cacheManagers].
   /// [Config.cacheKey] will be used as the key when adding the instance to
-  /// [cacheManagers].
+  /// [_cacheManagers].
   static set customCacheManager(CacheManager cacheManager) {
     _customCacheKey =
         cacheManager.store.storeKey; // This is the same key provided to Config.cacheKey.
-    cacheManagers[_customCacheKey] = cacheManager;
+    _cacheManagers[_customCacheKey] = cacheManager;
+  }
   }
 }
 


### PR DESCRIPTION
* Make fields private in custom cache manager

  - `DynamicCachedFontsCacheManager.defaultCacheKey` is now a private field
  - `DynamicCachedFontsCacheManager.cacheManagers` is now a private field
  - `DynamicCachedFontsCacheManager._cacheManagers` is now a final field

* DynamicCachedFontsCacheManager handles all cache related actions

  - Move `Utils.getCacheManager` into `DynamicCachedFontsCacheManager`
  - Move `Utils.handleCacheManager` into `DynamicCachedFontsCacheManager`
  - Migrate all APIs to use `DynamicCachedFontsCacheManager`'s methods

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No

<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
