### PR TITLE
Use static methods to compose the load method

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -469,11 +469,13 @@ class DynamicCachedFonts {
     String url, {
     @required String fontFamily,
     bool verboseLog = false,
+    @visibleForTesting FontLoader fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFont(
         url,
         fontFamily: fontFamily,
         verboseLog: verboseLog,
+        fontLoader: fontLoader,
       );
 
   /// Fetches the given [urls] from cache and loads them into the engine to be used.
@@ -503,10 +505,12 @@ class DynamicCachedFonts {
     List<String> urls, {
     @required String fontFamily,
     bool verboseLog = false,
+    @visibleForTesting FontLoader fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFamily(
         urls,
         fontFamily: fontFamily,
+        fontLoader: fontLoader,
       );
 
   /// Removes the given [url] can be loaded directly from cache.

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -4,7 +4,6 @@ library dynamic_cached_fonts;
 
 import 'dart:typed_data';
 
-import 'package:file/file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -290,71 +290,61 @@ class DynamicCachedFonts {
   ///
   /// This method can be called in `main()`, `initState()` or on button tap/click
   /// as needed.
-  Future<Iterable<File>> load() async {
+  Future<Iterable<FileInfo>> load() async {
     WidgetsFlutterBinding.ensureInitialized();
 
-    final Iterable<File> fontFiles = await Future.wait(
+    final List<String> downloadUrls = await Future.wait(
       urls.map(
-        (String url) => _handleCache(url),
+        (String url) async =>
+            _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url,
       ),
     );
 
-    if (!fontFiles.every(
-      (File font) => Utils.verifyFileExtension(font),
-    )) {
-      throw FlutterError(
-        'Invalid url. Unsupported file format. Supported file formats - otf and ttf',
-      );
-    }
+    Iterable<FileInfo> fontFiles;
 
-    final Iterable<Future<ByteData>> cachedFontBytes = fontFiles.map(
-      (File font) async => ByteData.view(
-        font.readAsBytesSync().buffer,
-      ),
-    );
-
-    if (_verboseLog)
-      devLog(
-        <String>['Font has been downloaded and cached!'],
+    try {
+      fontFiles = await loadCachedFamily(
+        downloadUrls,
+        fontFamily: fontFamily,
+        fontLoader: _fontLoader,
         verboseLog: _verboseLog,
       );
 
-    for (final Future<ByteData> bytes in cachedFontBytes) _fontLoader.addFont(bytes);
-    await _fontLoader.load();
+      // Checks whether any of the files is invalid.
+      // The validity is determined by parsing headers returned when the file was
+      // requested. The date/time is a file validity guarantee by the source.
+      // This was done to preserve `Cachemanager.getSingleFile`'s behaviour.
+      fontFiles
+          .where((FileInfo font) => font.validTill.isBefore(DateTime.now()))
+          .forEach((FileInfo font) => cacheFont(
+                font.originalUrl,
+                cacheStalePeriod: cacheStalePeriod,
+                maxCacheObjects: maxCacheObjects,
+                verboseLog: _verboseLog,
+              ));
+    } catch (_) {
+      devLog(
+        <String>['Font is not in cache.', 'Loading font now...'],
+        verboseLog: _verboseLog,
+      );
 
-    devLog(
-      <String>['Font has been loaded!'],
-      verboseLog: _verboseLog,
-    );
+      for (final String url in downloadUrls)
+        await cacheFont(
+          url,
+          cacheStalePeriod: cacheStalePeriod,
+          maxCacheObjects: maxCacheObjects,
+          verboseLog: _verboseLog,
+        );
+
+      fontFiles = await loadCachedFamily(
+        downloadUrls,
+        fontFamily: fontFamily,
+        fontLoader: _fontLoader,
+        verboseLog: _verboseLog,
+      );
+    }
 
     return fontFiles;
-  }
-
-  /// Uses [CacheManager.getSingleFile] to either download the file
-  /// if it isn't in the cache, or returns the file (as bytes) from cache.
-  Future<File> _handleCache(String url) async {
-    final String cacheKey = Utils.sanitizeUrl(url);
-
-    DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
-
-    final String downloadUrl =
-        _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url;
-
-    final File font = await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getSingleFile(
-      downloadUrl,
-      key: cacheKey,
-    );
-
-    devLog(
-      <String>[
-        'Font has been downloaded!\n',
-        'Font file path - ${font.path}',
-        font.statSync().toString(),
-      ],
-      verboseLog: _verboseLog,
-    );
-
-    return font;
   }
 
   /// Accepts [cacheManager] and [force] to provide a custom [CacheManager] for testing.
@@ -510,6 +500,7 @@ class DynamicCachedFonts {
       RawDynamicCachedFonts.loadCachedFamily(
         urls,
         fontFamily: fontFamily,
+        verboseLog: verboseLog,
         fontLoader: fontLoader,
       );
 

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -171,8 +171,11 @@ abstract class RawDynamicCachedFonts {
     String url, {
     @required String fontFamily,
     bool verboseLog = false,
+    @visibleForTesting FontLoader fontLoader,
   }) async {
     assert(verboseLog != null);
+
+    fontLoader ??= FontLoader(fontFamily);
 
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -185,10 +188,9 @@ abstract class RawDynamicCachedFonts {
 
     final ByteData cachedFontBytes = ByteData.view(fontBytes.buffer);
 
-    final FontLoader fontLoader = FontLoader(fontFamily)
-      ..addFont(
-        Future<ByteData>.value(cachedFontBytes),
-      );
+    fontLoader.addFont(
+      Future<ByteData>.value(cachedFontBytes),
+    );
 
     await fontLoader.load();
 
@@ -231,8 +233,11 @@ abstract class RawDynamicCachedFonts {
     List<String> urls, {
     @required String fontFamily,
     bool verboseLog = false,
+    @visibleForTesting FontLoader fontLoader,
   }) async {
     assert(verboseLog != null);
+
+    fontLoader ??= FontLoader(fontFamily);
 
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -252,8 +257,6 @@ abstract class RawDynamicCachedFonts {
 
       return ByteData.view(fontBytes.buffer);
     });
-
-    final FontLoader fontLoader = FontLoader(fontFamily);
 
     for (final Future<ByteData> bytes in cachedFontBytes) fontLoader.addFont(bytes);
 

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -252,6 +252,11 @@ abstract class RawDynamicCachedFonts {
       }),
     );
 
+    assert(
+      fontFiles.every((FileInfo font) => font != null),
+      'Font should already be cached to be loaded',
+    );
+
     final Iterable<Future<ByteData>> cachedFontBytes = fontFiles.map((FileInfo font) async {
       final Uint8List fontBytes = await font.file.readAsBytes();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  file: ^6.0.0
   firebase_storage: ^8.0.0
   flutter_cache_manager: ">=2.1.2 <=3.0.2"
   meta: ^1.3.0


### PR DESCRIPTION
- Add `fontLoader` parameter to `loadCachedFont`
- Add `fontLoader` parameter to `loadCachedFamily`
- Expose `fontLoader` only for testing

- `loadCachedFamily` - Add null check to font

- Use static methods to compose the load method
- `DynamicCachedFonts.load` now returns FileInfo instead of File
- Use `loadCachedFamily` and `cacheFont` to compose the load method
- Implement font file validity checker to preserve `Cachemanager.getSingleFile`'s behaviour

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No

> `DynamicCachedFonts.load` has a type change but the change was not released in v0.1.0. So this is not a breaking change.

> `loadCachedFamily` has only a change in the type of error thrown.

<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
