### PR TITLE
Remove unused deps; Use sdk's default deps

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,11 +182,9 @@ packages:
     version: "3.0.2"
   integration_test:
     dependency: "direct dev"
-    description:
-      name: integration_test
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2+3"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   js:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  integration_test: ^1.0.2+2
+  integration_test:
+    sdk: flutter
   lint: ^1.5.3
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  integration_test:
-    sdk: flutter
   lint: ^1.5.3
   pana: ^0.16.0


### PR DESCRIPTION
- Remove unused dependency on `integration_test`
- Update `integration_test` in the example to use the version provided by the flutter sdk

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
