### PR TITLE
Throw `StateError`s instead of assertions

### DIFF
--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -184,6 +184,10 @@ abstract class RawDynamicCachedFonts {
     final FileInfo font =
         await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
 
+    if (font == null) {
+      throw StateError('Font should already be cached to be loaded');
+    }
+
     final Uint8List fontBytes = await font.file.readAsBytes();
 
     final ByteData cachedFontBytes = ByteData.view(fontBytes.buffer);
@@ -252,10 +256,9 @@ abstract class RawDynamicCachedFonts {
       }),
     );
 
-    assert(
-      fontFiles.every((FileInfo font) => font != null),
-      'Font should already be cached to be loaded',
-    );
+    if (!fontFiles.every((FileInfo font) => font != null)) {
+      throw StateError('Font should already be cached to be loaded');
+    }
 
     final Iterable<Future<ByteData>> cachedFontBytes = fontFiles.map((FileInfo font) async {
       final Uint8List fontBytes = await font.file.readAsBytes();


### PR DESCRIPTION
- In b373d563, assertion error was used to indicate that the font was not in cache
However, this failed in release builds, where assertions were ignored.
`loadCachedFamily` now throws a `StateError` if the font has not been cached.
- To standardize the behaviour of the API, `loadCachedFont` also throws a `StateError`

Related commit: b373d56385fb71694337c866b1597e51f91b6c9e
Related PR: #47

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
