### PR TITLE
Remove separate step to get packages

### DIFF
--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -17,9 +17,6 @@ jobs:
         uses: subosito/flutter-action@v1
         with:
           channel: beta
-      
-      - name: Get flutter packages
-        run: flutter pub get
         
       - name: Activate dartdoc
         run: flutter pub global activate dartdoc

--- a/.github/workflows/example_integration_test.yml
+++ b/.github/workflows/example_integration_test.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Setup Chrome Driver
         uses: nanasess/setup-chromedriver@master
 
-      - name: Get flutter packages
-        run: flutter pub get
-
       - name: Run integration tests
         run: |
           export DISPLAY=:99
@@ -64,9 +61,6 @@ jobs:
         uses: subosito/flutter-action@v1
         with:
           channel: beta
-
-      - name: Get flutter packages
-        run: flutter pub get
 
       - name: Build android instrumentation test 
         working-directory: example

--- a/.github/workflows/package_unit_test.yml
+++ b/.github/workflows/package_unit_test.yml
@@ -17,9 +17,6 @@ jobs:
         uses: subosito/flutter-action@v1
         with:
           channel: beta
-      
-      - name: Get flutter packages
-        run: flutter pub get
 
       - name: Run unit tests
         run: flutter test


### PR DESCRIPTION
Most flutter commands run `flutter pub get` by default

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
