### PR TITLE
Refactor and rename Integration tests

### DIFF
--- a/example/integration_test/dynamic_cached_fonts_example_test.dart
+++ b/example/integration_test/dynamic_cached_fonts_example_test.dart
@@ -38,21 +38,21 @@ void main() {
       font = (await cachedFontLoader.load()).first;
     });
 
-    testWidgets('Font file is loaded into cache', (_) async {
+    testWidgets('should load font into cache', (_) async {
       expect(font, isNotNull);
     });
 
-    testWidgets('Loaded font file has a valid extension', (_) async {
+    testWidgets('should load font file with a valid extension', (_) async {
       final String fontFileName = font.file.basename;
 
       expect(fontFileName, endsWith('ttf'));
     });
 
-    testWidgets('Font can be loaded only once', (_) async {
+    testWidgets('should allow font to be loaded only once', (_) async {
       expect(cachedFontLoader.load(), throwsStateError);
     });
 
-    testWidgets('Font loader loads valid font file', (_) async {
+    testWidgets('should load valid font file', (_) async {
       final FileInfo downloadedFont = await cacheManager.downloadFile(
         fontUrl,
         key: '$cacheKey-test',
@@ -65,7 +65,7 @@ void main() {
     });
   });
 
-  testWidgets('DynamicCachedFonts.family loads all fonts into cache', (_) async {
+  testWidgets('DynamicCachedFonts.family should load all fonts into cache', (_) async {
     const List<String> fontUrls = <String>[
       firaSansBoldUrl,
       firaSansItalicUrl,
@@ -97,15 +97,15 @@ void main() {
       bucketRef = FirebaseStorage.instance.refFromURL(firebaseFontUrl);
     });
 
-    testWidgets('parses Firebase Bucket URL', (_) async {
+    testWidgets('should parse Firebase Bucket URL', (_) async {
       expect(font.originalUrl, equals(await bucketRef.getDownloadURL()));
     });
 
-    testWidgets('load() method parses Firebase Bucket Url and loads font', (_) async {
+    testWidgets('should load font into cache', (_) async {
       expect(font, isNotNull);
     });
 
-    testWidgets('Font loader loads valid font file from Firebase', (_) async {
+    testWidgets('should load valid font file from Firebase', (_) async {
       expect(
         font.file.readAsBytesSync(),
         orderedEquals(await bucketRef.getData()),
@@ -122,17 +122,17 @@ void main() {
       font = await cacheManager.getFileFromCache(cacheKey);
     });
 
-    testWidgets('DynamicCachedFonts.cacheFont loads font into cache', (_) async {
+    testWidgets('should load font into cache', (_) async {
       expect(font, isNotNull);
     });
 
-    testWidgets('DynamicCachedFonts.cacheFont loads font with a valid extension', (_) async {
+    testWidgets('should load font file with a valid extension', (_) async {
       final String fontFileName = font.file.basename;
 
       expect(fontFileName, endsWith('ttf'));
     });
 
-    testWidgets('throws UnsupportedError if file extension is not valid', (_) async {
+    testWidgets('should throw UnsupportedError if file extension is not valid', (_) async {
       const String woffUrl =
           'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/woff/FiraMono-Regular.woff';
 
@@ -146,16 +146,14 @@ void main() {
           key: cacheKey,
         ));
 
-    testWidgets('DynamicCachedFonts.canLoadFont returns true when font is available in cache',
-        (_) async {
+    testWidgets('should return true when font is available in cache', (_) async {
       expect(
         await DynamicCachedFonts.canLoadFont(fontUrl),
         isTrue,
       );
     });
 
-    testWidgets('DynamicCachedFonts.canLoadFont returns false when font is not available in cache',
-        (_) async {
+    testWidgets('should return false when font is not available in cache', (_) async {
       await cacheManager.removeFile(cacheKey);
 
       // Temporary hack for file removal
@@ -186,18 +184,18 @@ void main() {
       );
     });
 
-    testWidgets('loads font into cache', (_) async {
+    testWidgets('should load font into cache', (_) async {
       expect(font, isNotNull);
     });
 
-    testWidgets('loads valid font file', (_) async {
+    testWidgets('should load valid font file', (_) async {
       expect(
         downloadedFont.file.readAsBytesSync(),
         orderedEquals(font.file.readAsBytesSync()),
       );
     });
 
-    testWidgets('loads font into the Flutter Engine', (_) async {
+    testWidgets('should load font into the Flutter Engine', (_) async {
       // This tests that load() is being called in loadCachedFamily.
       // A single instance of FontLoader can only be loaded once, so if
       // StateError is thrown, it means that load() has already been called.
@@ -232,11 +230,11 @@ void main() {
       );
     });
 
-    testWidgets('loads font into cache', (_) async {
+    testWidgets('should load all fonts into cache', (_) async {
       expect(fonts, everyElement(isNotNull));
     });
 
-    testWidgets('loads valid font files', (_) async {
+    testWidgets('should load valid font files', (_) async {
       final List<Uint8List> downloadedFontBytes = downloadedFonts
           .map((FileInfo downloadedFont) => downloadedFont.file.readAsBytesSync())
           .toList();
@@ -249,7 +247,7 @@ void main() {
       }
     });
 
-    testWidgets('loads font into the Flutter Engine', (_) async {
+    testWidgets('should load the font family into the Flutter Engine', (_) async {
       // This tests that load() is being called in loadCachedFamily.
       // A single instance of FontLoader can only be loaded once, so if
       // StateError is thrown, it means that load() has already been called.
@@ -257,7 +255,7 @@ void main() {
     });
   });
 
-  testWidgets('DynamicCachedFonts.removeCachedFont removes the font from cache', (_) async {
+  testWidgets('DynamicCachedFonts.removeCachedFont should remove the font from cache', (_) async {
     await cacheManager.downloadFile(fontUrl, key: cacheKey);
 
     await DynamicCachedFonts.removeCachedFont(fontUrl);

--- a/example/integration_test/dynamic_cached_fonts_example_test.dart
+++ b/example/integration_test/dynamic_cached_fonts_example_test.dart
@@ -95,16 +95,17 @@ void main() {
     setUpAll(() async {
       await Firebase.initializeApp();
 
-      await DynamicCachedFonts.fromFirebase(
+      fontFile = (await DynamicCachedFonts.fromFirebase(
         bucketUrl: firebaseFontUrl,
         fontFamily: firebaseFontName,
-      ).load();
+      ).load())
+          .first;
 
       bucketRef = FirebaseStorage.instance.refFromURL(firebaseFontUrl);
+    });
 
-      final String cacheKey = cacheKeyFromUrl(await bucketRef.getDownloadURL());
-
-      fontFile = await cacheManager.getFileFromCache(cacheKey);
+    testWidgets('parses Firebase Bucket URL', (_) async {
+      expect(fontFile.originalUrl, equals(await bucketRef.getDownloadURL()));
     });
 
     testWidgets('load() method parses Firebase Bucket Url and loads font', (_) async {

--- a/example/integration_test/dynamic_cached_fonts_example_test.dart
+++ b/example/integration_test/dynamic_cached_fonts_example_test.dart
@@ -260,11 +260,6 @@ void main() {
   testWidgets('DynamicCachedFonts.removeCachedFont removes the font from cache', (_) async {
     await cacheManager.downloadFile(fontUrl, key: cacheKey);
 
-    expect(
-      await cacheManager.getFileFromCache(cacheKey),
-      isNotNull,
-    );
-
     await DynamicCachedFonts.removeCachedFont(fontUrl);
 
     // Temporary hack for file removal


### PR DESCRIPTION
- Refactor firebase tests and add test that firebase bucket url is parsed correctly

Tests affected -

- `DynamicCachedFonts.fromFirebase` (setUpAll)
- `DynamicCachedFonts.fromFirebase` parses Firebase Bucket URL

- Isolate tests, remove inter-dependency and refactor variables

To isolate tests and remove inter-dependency -

- Add top level `teardown` to empty cache after each step
- Convert `setUpAll` in groups to `setUp`

- Use built in matchers for better error logging (`endsWith`, `orderedEquals`, `everyElement`)
- Use `FileInfo`s returned by `DynamicCachedFonts.*` instead of manually getting them from cache
- Simplify font file extension validator by using `endsWith` matcher
- Add helper method - `awaitedMap`
- Import `dart:typed_data` for `Uint8List`
- Don't import `flutter_cache_manager` as it is exported by `dynamic_cached_fonts`

- Remove unnecessary expect statement
Test affected - `DynamicCachedFonts.removeCachedFont` removes the font from cache

- Rename integration tests to follow test naming conventions

## Related Issues

N/A

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or the feature I am adding.
- [x] All existing and new tests are passing.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
