### PR TITLE
Remove verbose log

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -94,25 +94,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts({
-    @required
-        String url,
-    @required
-        this.fontFamily,
+    @required String url,
+    @required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
           'fontFamily cannot be null or empty',
@@ -121,9 +107,7 @@ class DynamicCachedFonts {
           url != null && url != '',
           'url cannot be null or empty',
         ),
-        assert(verboseLog != null),
         urls = <String>[url],
-        _verboseLog = verboseLog,
         _isFirebaseURL = false,
         _loaded = false;
 
@@ -155,25 +139,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts.family({
-    @required
-        this.urls,
-    @required
-        this.fontFamily,
+    @required this.urls,
+    @required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
           'fontFamily cannot be null or empty',
@@ -188,8 +158,6 @@ class DynamicCachedFonts {
           ),
           'url cannot be null or empty',
         ),
-        assert(verboseLog != null),
-        _verboseLog = verboseLog,
         _isFirebaseURL = false,
         _loaded = false;
 
@@ -221,25 +189,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts.fromFirebase({
-    @required
-        String bucketUrl,
-    @required
-        this.fontFamily,
+    @required String bucketUrl,
+    @required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != null && fontFamily != '',
           'fontFamily cannot be null or empty',
@@ -248,8 +202,6 @@ class DynamicCachedFonts {
           bucketUrl != null && bucketUrl != '',
           'bucketUrl cannot be null or empty',
         ),
-        assert(verboseLog != null),
-        _verboseLog = verboseLog,
         urls = <String>[bucketUrl],
         _isFirebaseURL = true,
         _loaded = false;
@@ -288,14 +240,6 @@ class DynamicCachedFonts {
   /// for [CacheManager].
   final Duration cacheStalePeriod;
 
-  /// A debug property used to specify whether detailed
-  /// logs should be printed for debugging.
-  ///
-  /// Defaults to false.
-  ///
-  /// _Tip: To log only in debug mode, set the value to [kReleaseMode]_.
-  final bool _verboseLog;
-
   /// Determines whether [url] is a firebase storage bucket url.
   final bool _isFirebaseURL;
 
@@ -315,8 +259,7 @@ class DynamicCachedFonts {
 
     final List<String> downloadUrls = await Future.wait(
       urls.map(
-        (String url) async =>
-            _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url,
+        (String url) async => _isFirebaseURL ? await Utils.handleUrl(url) : url,
       ),
     );
 
@@ -326,7 +269,6 @@ class DynamicCachedFonts {
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
-        verboseLog: _verboseLog,
       );
 
       // Checks whether any of the files is invalid.
@@ -339,26 +281,20 @@ class DynamicCachedFonts {
                 font.originalUrl,
                 cacheStalePeriod: cacheStalePeriod,
                 maxCacheObjects: maxCacheObjects,
-                verboseLog: _verboseLog,
               ));
     } catch (_) {
-      devLog(
-        <String>['Font is not in cache.', 'Loading font now...'],
-        verboseLog: _verboseLog,
-      );
+      devLog(['Font is not in cache.', 'Loading font now...']);
 
       for (final String url in downloadUrls)
         await cacheFont(
           url,
           cacheStalePeriod: cacheStalePeriod,
           maxCacheObjects: maxCacheObjects,
-          verboseLog: _verboseLog,
         );
 
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
-        verboseLog: _verboseLog,
       );
     }
 
@@ -417,28 +353,15 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> cacheFont(
     String url, {
     Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     int maxCacheObjects = kDefaultMaxCacheObjects,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   }) =>
       RawDynamicCachedFonts.cacheFont(
         url,
         cacheStalePeriod: cacheStalePeriod,
         maxCacheObjects: maxCacheObjects,
-        verboseLog: verboseLog,
       );
 
   /// Checks whether the given [url] can be loaded directly from cache.
@@ -446,25 +369,7 @@ class DynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
-  static Future<bool> canLoadFont(
-    String url, {
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-  }) =>
-      RawDynamicCachedFonts.canLoadFont(
-        url,
-        verboseLog: verboseLog,
-      );
+  static Future<bool> canLoadFont(String url) => RawDynamicCachedFonts.canLoadFont(url);
 
   /// Fetches the given [url] from cache and loads it as an asset.
   ///
@@ -474,29 +379,14 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> loadCachedFont(
     String url, {
-    @required
-        String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader fontLoader,
+    @required String fontFamily,
+    @visibleForTesting FontLoader fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFont(
         url,
         fontFamily: fontFamily,
-        verboseLog: verboseLog,
         fontLoader: fontLoader,
       );
 
@@ -516,29 +406,14 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
-    @required
-        String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader fontLoader,
+    @required String fontFamily,
+    @visibleForTesting FontLoader fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFamily(
         urls,
         fontFamily: fontFamily,
-        verboseLog: verboseLog,
         fontLoader: fontLoader,
       );
 
@@ -547,9 +422,7 @@ class DynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  static Future<void> removeCachedFont(String url) => RawDynamicCachedFonts.removeCachedFont(
-        url,
-      );
+  static Future<void> removeCachedFont(String url) => RawDynamicCachedFonts.removeCachedFont(url);
 
   /// Used to specify whether detailed logs should be printed for debugging.
   ///

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -58,27 +58,11 @@ abstract class RawDynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> cacheFont(
     String url, {
-    @required
-        int maxCacheObjects,
-    @required
-        Duration cacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
+    @required int maxCacheObjects,
+    @required Duration cacheStalePeriod,
   }) async {
-    assert(verboseLog != null);
-
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
@@ -93,14 +77,11 @@ abstract class RawDynamicCachedFonts {
 
     Utils.verifyFileExtension(font.file);
 
-    devLog(
-      <String>[
-        'Font file downloaded\n',
-        'Validity: ${font.validTill}',
-        'Download URL: ${font.originalUrl}',
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog([
+      'Font file downloaded\n',
+      'Validity: ${font.validTill}',
+      'Download URL: ${font.originalUrl}',
+    ]);
 
     return font;
   }
@@ -110,23 +91,7 @@ abstract class RawDynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
-  static Future<bool> canLoadFont(
-    String url, {
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-  }) async {
-    assert(verboseLog != null);
-
+  static Future<bool> canLoadFont(String url) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
@@ -147,10 +112,7 @@ abstract class RawDynamicCachedFonts {
         ].join(),
       );
     } catch (e) {
-      devLog(
-        <String>[e.toString()],
-        verboseLog: verboseLog,
-      );
+      devLog([e.toString()]);
     }
     return font != null;
   }
@@ -166,27 +128,11 @@ abstract class RawDynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> loadCachedFont(
     String url, {
-    @required
-        String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader fontLoader,
+    @required String fontFamily,
+    @visibleForTesting FontLoader fontLoader,
   }) async {
-    assert(verboseLog != null);
-
     fontLoader ??= FontLoader(fontFamily);
 
     WidgetsFlutterBinding.ensureInitialized();
@@ -210,14 +156,11 @@ abstract class RawDynamicCachedFonts {
 
     await fontLoader.load();
 
-    devLog(
-      <String>[
-        'Font has been loaded!',
-        'This font file is valid till - ${font.validTill}',
-        'File stat - ${font.file.statSync()}'
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog([
+      'Font has been loaded!',
+      'This font file is valid till - ${font.validTill}',
+      'File stat - ${font.file.statSync()}'
+    ]);
 
     return font;
   }
@@ -238,27 +181,11 @@ abstract class RawDynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
-    @required
-        String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader fontLoader,
+    @required String fontFamily,
+    @visibleForTesting FontLoader fontLoader,
   }) async {
-    assert(verboseLog != null);
-
     fontLoader ??= FontLoader(fontFamily);
 
     WidgetsFlutterBinding.ensureInitialized();
@@ -288,10 +215,7 @@ abstract class RawDynamicCachedFonts {
 
     await fontLoader.load();
 
-    devLog(
-      <String>['Font has been loaded!'],
-      verboseLog: verboseLog,
-    );
+    devLog(['Font has been loaded!']);
 
     return fontFiles;
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,10 +26,9 @@ const int kDefaultMaxCacheObjects = 200;
 @internal
 void devLog(
   List<String> messageList, {
-  bool verboseLog,
   bool overrideLoggerConfig,
 }) {
-  if (overrideLoggerConfig ?? (Utils.shouldVerboseLog || verboseLog)) {
+  if (overrideLoggerConfig ?? Utils.shouldVerboseLog) {
     final String message = messageList.join('\n');
     dev.log(
       message,
@@ -167,21 +166,15 @@ class Utils {
   /// Checks whether the received [url] is a Cloud Storage url or an https url.
   /// If the url points to a Cloud Storage bucket, then a download url
   /// is generated using the Firebase SDK.
-  static Future<String> handleUrl(
-    String url, {
-    @required bool verboseLog,
-  }) async {
+  static Future<String> handleUrl(String url) async {
     final Reference ref = FirebaseStorage.instance.refFromURL(url);
 
-    devLog(
-      <String>[
-        'Created Firebase Storage reference with following values -\n',
-        'Bucket name - ${ref.bucket}',
-        'Object name - ${ref.name}',
-        'Object path - ${ref.fullPath}',
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog([
+      'Created Firebase Storage reference with following values -\n',
+      'Bucket name - ${ref.bucket}',
+      'Object name - ${ref.name}',
+      'Object path - ${ref.fullPath}',
+    ]);
 
     return ref.getDownloadURL();
   }


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

Yes

I have modified or deleted the following public APIs which will break the users' code - 

`verboseLog` argument is no longer supported. This option was deprecated in `v0.2.0`.
