### PR TITLE
Use `flutter test` instead of `flutter driver` to run integration tests

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -171,10 +171,11 @@ jobs:
       - name: Run Integration Tests
         env:
           OS: ${{ matrix.os }}
+          FIREBASE_STORAGE_FONT_URL: ${{ secrets.FIREBASE_STORAGE_FONT_URL }}
         run: |
          if ( "$env:OS" -eq "ubuntu-latest" ) { Xvfb -ac :99 &; $env:DISPLAY=":99" }
 
          flutter test `
-           --dart-define FIREBASE_STORAGE_FONT_URL=$FIREBASE_STORAGE_FONT_URL `
+           --dart-define FIREBASE_STORAGE_FONT_URL=$env:FIREBASE_STORAGE_FONT_URL `
            --device-id ${{ matrix.flutter_os }} `
            ./integration_test/dynamic_cached_fonts_example_test.dart

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -174,8 +174,7 @@ jobs:
         run: |
          if ( "$env:OS" -eq "ubuntu-latest" ) { Xvfb -ac :99 &; $env:DISPLAY=":99" }
 
-         flutter driver `
-           --driver test_driver/integration_test.dart `
-           --target ./integration_test/dynamic_cached_fonts_example_test.dart `
+         flutter test `
            --dart-define FIREBASE_STORAGE_FONT_URL=$FIREBASE_STORAGE_FONT_URL `
-           --device-id ${{ matrix.flutter_os }}
+           --device-id ${{ matrix.flutter_os }} `
+           ./integration_test/dynamic_cached_fonts_example_test.dart


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
