### PR TITLE
Add pre checks for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,31 @@ jobs:
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v8.1
+
+      - name: Check that necessary files have been modified
+        env:
+          changelog: ${{ CHANGELOG.md }}
+          version_file: ${{ pubspec.yaml }}
+          example_deps: ${{ example/pubspec.lock }}
+          IS_VALID: |
+            ${{
+              contains(steps.changed-files.outputs.modified_files, changelog) &&
+              contains(steps.changed-files.outputs.modified_files, version_file) &&
+              contains(steps.changed-files.outputs.modified_files, example_deps)
+            }}
+        run: |
+          if [[ "$IS_VALID" ]]
+          then
+            echo "All necessary files have been modified. Ready to release!"
+          else
+            echo "Please modify $changelog, $version_file and $example_deps to release package"
+          fi
 
       - name: Wait on tests
         uses: lewagon/wait-on-check-action@master


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

no
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
