### PR TITLE
Update `firebase_storage` constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_storage: ">8.0.0"
+  firebase_storage: ">=8.0.0 <11.0.0"
   flutter_cache_manager: ^3.1.2
   meta: ^1.3.0
 


### PR DESCRIPTION
Allow older compatible versions and newer versions up to the latest major version for `firebase_storage`

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
