### PR TITLE
Update triggers for release pre-check workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -32,4 +32,8 @@ jobs:
         with:
           script: |
             const labeler = require('./dev/ci/labeler.js')
-            await labeler.addReleaseLabel({ github, context })
+            await labeler.addReleaseLabel({
+              github,
+              context,
+              workflow: 'release_pre_check.yml',
+            })

--- a/.github/workflows/release_pre_check.yml
+++ b/.github/workflows/release_pre_check.yml
@@ -20,31 +20,31 @@ jobs:
         run: echo "::set-output name=logs::$(cat publish.log)"
 
   post_result:
-   name: Post pre-check result
-   runs-on: ubuntu-latest
+    name: Post pre-check result
+    runs-on: ubuntu-latest
 
-   needs: [ publish_to_pub_pre_check ]
+    needs: [ publish_to_pub_pre_check ]
 
-   steps:
-     - name: Post pre-check result to check run
-       uses: actions/github-script@v4
-       env:
-         STATUS: ${{ needs.publish_to_pub_pre_check.result == 'success' }}
-         LOGS: ${{ needs.publish_to_pub_pre_check.outputs.logs }}
-       with:
-         script: |
-           const { STATUS, LOGS } = process.env;
-           const resultPoster = require('./dev/ci/resultPoster.js')
-           await resultPoster.postPreCheckResult({
-             github,
-             context,
-             output: STATUS ? {
-              title: 'Publish to Pub',
-              summary: 'Successful action - `dart pub lish --dry-run`! :tada:',
-              conclusion: 'success',
-             } : {
+    steps:
+      - name: Post pre-check result to check run
+        uses: actions/github-script@v4
+        env:
+          STATUS: ${{ needs.publish_to_pub_pre_check.result == 'success' }}
+          LOGS: ${{ needs.publish_to_pub_pre_check.outputs.logs }}
+        with:
+          script: |
+            const { STATUS, LOGS } = process.env;
+            const resultPoster = require('./dev/ci/resultPoster.js')
+            await resultPoster.postPreCheckResult({
+              github,
+              context,
+              output: STATUS ? {
                title: 'Publish to Pub',
-               summary: 'Output logs for failed action - `dart pub lish --dry-run`',
-               logs: LOGS,
-               conclusion: 'failure',
-           })
+               summary: 'Successful action - `dart pub lish --dry-run`! :tada:',
+               conclusion: 'success',
+              } : {
+                title: 'Publish to Pub',
+                summary: 'Output logs for failed action - `dart pub lish --dry-run`',
+                logs: LOGS,
+                conclusion: 'failure',
+            })

--- a/.github/workflows/release_pre_check.yml
+++ b/.github/workflows/release_pre_check.yml
@@ -1,50 +1,11 @@
 name: Release pre-check
 on:
-  pull_request:
-    types: [labeled]
+  - workflow_dispatch
 
 jobs:
-  release_files_changed_pre_check:
-    name: Release files changed pre-check
-    runs-on: ubuntu-latest
-
-    if: ${{ github.event.label.name == 'release :tada:' }}
-
-    steps:
-      - name: Checkout repository code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v8.1
-
-      - name: Check that necessary files have been modified
-        env:
-          changelog: ${{ CHANGELOG.md }}
-          version_file: ${{ pubspec.yaml }}
-          example_deps: ${{ example/pubspec.lock }}
-          IS_VALID: |
-            ${{
-              contains(steps.changed-files.outputs.modified_files, changelog) &&
-              contains(steps.changed-files.outputs.modified_files, version_file) &&
-              contains(steps.changed-files.outputs.modified_files, example_deps)
-            }}
-        run: |
-          if [[ "$IS_VALID" ]]
-          then
-            echo "All necessary files have been modified. Ready to release!"
-          else
-            echo "Please modify $changelog, $version_file and $example_deps to release package"
-          fi
-
   publish_to_pub_pre_check:
     name: Publish to Pub pre-check
     runs-on: ubuntu-latest
-
-    if: ${{ github.event.label.name == 'release :tada:' }}
-
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
@@ -53,4 +14,37 @@ jobs:
         uses: dart-lang/setup-dart@v1
 
       - name: Run publisher in dry run mode
-        run: dart pub lish --dry-run
+        run: dart pub lish --dry-run | tee publish.log
+
+      - name: Set output
+        run: echo "::set-output name=logs::$(cat publish.log)"
+
+  post_result:
+   name: Post pre-check result
+   runs-on: ubuntu-latest
+
+   needs: [ publish_to_pub_pre_check ]
+
+   steps:
+     - name: Post pre-check result to check run
+       uses: actions/github-script@v4
+       env:
+         STATUS: ${{ needs.publish_to_pub_pre_check.result == 'success' }}
+         LOGS: ${{ needs.publish_to_pub_pre_check.outputs.logs }}
+       with:
+         script: |
+           const { STATUS, LOGS } = process.env;
+           const resultPoster = require('./dev/ci/resultPoster.js')
+           await resultPoster.postPreCheckResult({
+             github,
+             context,
+             output: STATUS ? {
+              title: 'Publish to Pub',
+              summary: 'Successful action - `dart pub lish --dry-run`! :tada:',
+              conclusion: 'success',
+             } : {
+               title: 'Publish to Pub',
+               summary: 'Output logs for failed action - `dart pub lish --dry-run`',
+               logs: LOGS,
+               conclusion: 'failure',
+           })

--- a/dev/ci/labeler.js
+++ b/dev/ci/labeler.js
@@ -1,3 +1,5 @@
+/*eslint-env node*/
+
 exports.addRevertLabel = async ({ github, context }) => {
   const { data: pr } = await github.pulls.get({
     owner: context.repo.owner,

--- a/dev/ci/resultPoster.js
+++ b/dev/ci/resultPoster.js
@@ -1,0 +1,16 @@
+exports.postPreCheckResult = ({ github, context, output }) => {
+    return github.checks.create({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name: 'Release Pre-Check',
+        head_sha: context.sha,
+        status: 'completed',
+        conclusion: output.conclusion,
+        output: {
+            title: 'Logs for Pre-Check: ' + output.title,
+            summary: output.summary,
+            text: output.logs,
+        },
+        completed_at: new Date().toISOString(),
+    })
+}

--- a/dev/ci/resultPoster.js
+++ b/dev/ci/resultPoster.js
@@ -1,3 +1,5 @@
+/*eslint-env node*/
+
 exports.postPreCheckResult = ({ github, context, output }) => {
     return github.checks.create({
         owner: context.repo.owner,

--- a/dev/ci/utils.js
+++ b/dev/ci/utils.js
@@ -1,3 +1,5 @@
+/*eslint-env node*/
+
 exports.getChangedFiles = async ({ github, context }) => {
   const listFilesOptions = github.pulls.listFiles.endpoint.merge({
     owner: context.repo.owner,

--- a/dev/ci/utils.js
+++ b/dev/ci/utils.js
@@ -1,0 +1,11 @@
+exports.getChangedFiles = async ({ github, context }) => {
+  const listFilesOptions = github.pulls.listFiles.endpoint.merge({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+  });
+
+  const listFilesResponse = await github.paginate(listFilesOptions);
+
+  return listFilesResponse.map(file => file.filename);
+}


### PR DESCRIPTION
- Trigger `release_pre_check.yml` workflow using `workflow_dispatch`
- Update logic and implementation for release labeler "bot"
- Move general purpose shared functions (`getChangedFiles`) to `utils.js`
- Post results as a check run result using Github Checks API (`resultPoster.js`)

New logic:
Labeler bot calls `addReleaseLabel` which applies the release label only if the required files were modified.
Once the release label is added, the release pre-check workflow is dispatched.
The release pre-check workflow tries to publish the package (in dry run mode) and posts its results using the Github Checks API

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
