### PR TITLE
Release v0.3.1 - Update dependency constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.1
+
+**Dependency Updates**
+
+- Added support for the latest version of `firebase_storage`. Minimum supported version continues to be v8.0.0
+
 # 0.3.0
 
 Stable Null safety release

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_cached_fonts
 description: A customizable dynamic font loader for flutter with caching enabled.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/sidrao2006/dynamic_cached_fonts
 
 environment:


### PR DESCRIPTION
Added support for the latest version of `firebase_storage`.
Minimum supported version continues to be v8.0.0

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
