### PR TITLE
Add workflow to auto build and deploy example Github Pages

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -1,0 +1,41 @@
+name: Github Pages Example
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'example/web/**'
+      - 'example/pubspec.*'
+      - 'example/lib/**'
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy Example to Github Pages
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: example
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v1
+        with:
+          channel: beta
+
+      - name: Build example for web
+        run: |
+          flutter build web \
+          --base-href /dynamic_cached_fonts/ \
+          --dart-define FIREBASE_STORAGE_FONT_URL=$FIREBASE_STORAGE_FONT_URL \
+          --no-source-maps \
+          --release
+
+      - name: Deploy to Github Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: build/web


### PR DESCRIPTION
- Runs only when relevant files in example/ are changed
- Builds the app using `flutter build web`
- Deploy the app to Github Pages

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
