### PR TITLE
Revert "Don't checkout the repo unnecessarily"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,6 +17,9 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
 
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Add 'revert' label to relevant PRs
         uses: actions/github-script@v4
         with:


### PR DESCRIPTION
Reverts sidrao2006/dynamic_cached_fonts#134

Reason: Seems like checkout was required since labeler bot runs script located in `dev/ci/labeler.js`