### PR TITLE
Enable gh pages manual deployment

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -7,6 +7,7 @@ on:
       - 'example/web/**'
       - 'example/pubspec.*'
       - 'example/lib/**'
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
