### PR TITLE
Update release labeler strategy and refactor/format js scripts

### DIFF
--- a/dev/ci/resultPoster.js
+++ b/dev/ci/resultPoster.js
@@ -1,17 +1,18 @@
 /*eslint-env node*/
 
 exports.postPreCheckResult = ({ github, context, output }) => {
+    const { owner, repo } = context.repo;
+    const { title, summary, text, conclusion } = output;
+
     return github.checks.create({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
+        owner, repo,
         name: 'Release Pre-Check',
         head_sha: context.sha,
         status: 'completed',
-        conclusion: output.conclusion,
+        conclusion,
         output: {
-            title: 'Logs for Pre-Check: ' + output.title,
-            summary: output.summary,
-            text: output.logs,
+            title: 'Logs for Pre-Check: ' + title,
+            summary, text
         },
         completed_at: new Date().toISOString(),
     })

--- a/dev/ci/utils.js
+++ b/dev/ci/utils.js
@@ -1,13 +1,21 @@
 /*eslint-env node*/
 
-exports.getChangedFiles = async ({ github, context }) => {
-  const listFilesOptions = github.pulls.listFiles.endpoint.merge({
+exports.getPRCommitMessages = async ({ github, context }) => {
+  const { data: commits } = await github.pulls.listCommits({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.payload.pull_request.number,
   });
 
-  const listFilesResponse = await github.paginate(listFilesOptions);
+  return commits.map(commit => commit.commit.message);
+}
 
-  return listFilesResponse.map(file => file.filename);
+exports.PRTitleIncludes = async ({ github, context }, title) => {
+  const { data: pr } = await github.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+  });
+
+  return pr.title.includes(title);
 }


### PR DESCRIPTION
- Release labeler now checks to see if either the PR title contains "Release" or if any of the commits is a release commit
- Format and cleanup code

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
