### PR TITLE
Update gitignore (pubspec.lock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 .pub-cache/
 .pub/
 build/
-pubspec.lock
+/pubspec.lock
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
Pub's new gitignore validator requires this chnage

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
