### PR TITLE
Fix revert labeler behaviour (async-await)

### DIFF
--- a/dev/ci/labeler.js
+++ b/dev/ci/labeler.js
@@ -4,7 +4,7 @@ exports.addRevertLabel = async ({ github, context }) => {
   const utils = require('./utils.js');
   const { owner, repo } = context.repo;
 
-  if (utils.PRTitleIncludes({ github, context }, "Revert"))
+  if (await utils.PRTitleIncludes({ github, context }, "Revert"))
     github.issues.addLabels({
       owner, repo,
       issue_number: context.payload.pull_request.number,


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
