### PR TITLE
Drop support for deprecated API - `verboseLog`

### DIFF
--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -94,23 +94,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts({
     required String url,
     required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != '',
           'fontFamily cannot be empty',
@@ -120,7 +108,6 @@ class DynamicCachedFonts {
           'url cannot be empty',
         ),
         urls = <String>[url],
-        _verboseLog = verboseLog,
         _isFirebaseURL = false,
         _loaded = false;
 
@@ -152,23 +139,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts.family({
     required this.urls,
     required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != '',
           'fontFamily cannot be empty',
@@ -183,7 +158,6 @@ class DynamicCachedFonts {
           ),
           'url cannot be empty',
         ),
-        _verboseLog = verboseLog,
         _isFirebaseURL = false,
         _loaded = false;
 
@@ -215,23 +189,11 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   DynamicCachedFonts.fromFirebase({
     required String bucketUrl,
     required this.fontFamily,
     this.maxCacheObjects = kDefaultMaxCacheObjects,
     this.cacheStalePeriod = kDefaultCacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   })  : assert(
           fontFamily != '',
           'fontFamily cannot be empty',
@@ -240,7 +202,6 @@ class DynamicCachedFonts {
           bucketUrl != '',
           'bucketUrl cannot be empty',
         ),
-        _verboseLog = verboseLog,
         urls = <String>[bucketUrl],
         _isFirebaseURL = true,
         _loaded = false;
@@ -279,14 +240,6 @@ class DynamicCachedFonts {
   /// for [CacheManager].
   final Duration cacheStalePeriod;
 
-  /// A debug property used to specify whether detailed
-  /// logs should be printed for debugging.
-  ///
-  /// Defaults to false.
-  ///
-  /// _Tip: To log only in debug mode, set the value to [kReleaseMode]_.
-  final bool _verboseLog;
-
   /// Determines whether [url] is a firebase storage bucket url.
   final bool _isFirebaseURL;
 
@@ -306,8 +259,7 @@ class DynamicCachedFonts {
 
     final List<String> downloadUrls = await Future.wait(
       urls.map(
-        (String url) async =>
-            _isFirebaseURL ? await Utils.handleUrl(url, verboseLog: _verboseLog) : url,
+        (String url) async => _isFirebaseURL ? await Utils.handleUrl(url) : url,
       ),
     );
 
@@ -317,7 +269,6 @@ class DynamicCachedFonts {
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
-        verboseLog: _verboseLog,
       );
 
       // Checks whether any of the files is invalid.
@@ -330,26 +281,20 @@ class DynamicCachedFonts {
                 font.originalUrl,
                 cacheStalePeriod: cacheStalePeriod,
                 maxCacheObjects: maxCacheObjects,
-                verboseLog: _verboseLog,
               ));
     } catch (_) {
-      devLog(
-        <String>['Font is not in cache.', 'Loading font now...'],
-        verboseLog: _verboseLog,
-      );
+      devLog(<String>['Font is not in cache.', 'Loading font now...']);
 
       for (final String url in downloadUrls)
         await cacheFont(
           url,
           cacheStalePeriod: cacheStalePeriod,
           maxCacheObjects: maxCacheObjects,
-          verboseLog: _verboseLog,
         );
 
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
-        verboseLog: _verboseLog,
       );
     }
 
@@ -408,28 +353,15 @@ class DynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> cacheFont(
     String url, {
     Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     int maxCacheObjects = kDefaultMaxCacheObjects,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   }) =>
       RawDynamicCachedFonts.cacheFont(
         url,
         cacheStalePeriod: cacheStalePeriod,
         maxCacheObjects: maxCacheObjects,
-        verboseLog: verboseLog,
       );
 
   /// Checks whether the given [url] can be loaded directly from cache.
@@ -437,25 +369,7 @@ class DynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
-  static Future<bool> canLoadFont(
-    String url, {
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-  }) =>
-      RawDynamicCachedFonts.canLoadFont(
-        url,
-        verboseLog: verboseLog,
-      );
+  static Future<bool> canLoadFont(String url) => RawDynamicCachedFonts.canLoadFont(url);
 
   /// Fetches the given [url] from cache and loads it as an asset.
   ///
@@ -465,28 +379,14 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> loadCachedFont(
     String url, {
     required String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader? fontLoader,
+    @visibleForTesting FontLoader? fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFont(
         url,
         fontFamily: fontFamily,
-        verboseLog: verboseLog,
         fontLoader: fontLoader,
       );
 
@@ -506,28 +406,14 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
     required String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader? fontLoader,
+    @visibleForTesting FontLoader? fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFamily(
         urls,
         fontFamily: fontFamily,
-        verboseLog: verboseLog,
         fontLoader: fontLoader,
       );
 

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -58,22 +58,10 @@ abstract class RawDynamicCachedFonts {
   ///
   ///   It is used to specify the cache configuration, [Config],
   ///   for [CacheManager].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> cacheFont(
     String url, {
     required int maxCacheObjects,
     required Duration cacheStalePeriod,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
   }) async {
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -89,14 +77,11 @@ abstract class RawDynamicCachedFonts {
 
     Utils.verifyFileExtension(font.file);
 
-    devLog(
-      <String>[
-        'Font file downloaded\n',
-        'Validity: ${font.validTill}',
-        'Download URL: ${font.originalUrl}',
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog(<String>[
+      'Font file downloaded\n',
+      'Validity: ${font.validTill}',
+      'Download URL: ${font.originalUrl}',
+    ]);
 
     return font;
   }
@@ -106,21 +91,7 @@ abstract class RawDynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
-  static Future<bool> canLoadFont(
-    String url, {
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-  }) async {
+  static Future<bool> canLoadFont(String url) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
@@ -142,23 +113,10 @@ abstract class RawDynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<FileInfo> loadCachedFont(
     String url, {
     required String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader? fontLoader,
+    @visibleForTesting FontLoader? fontLoader,
   }) async {
     fontLoader ??= FontLoader(fontFamily);
 
@@ -183,14 +141,11 @@ abstract class RawDynamicCachedFonts {
 
     await fontLoader.load();
 
-    devLog(
-      <String>[
-        'Font has been loaded!',
-        'This font file is valid till - ${font.validTill}',
-        'File stat - ${font.file.statSync()}'
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog(<String>[
+      'Font has been loaded!',
+      'This font file is valid till - ${font.validTill}',
+      'File stat - ${font.file.statSync()}'
+    ]);
 
     return font;
   }
@@ -211,23 +166,10 @@ abstract class RawDynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
-  ///
-  /// - The [verboseLog] is a debug property used to specify whether detailed
-  ///   logs should be printed for debugging.
-  ///
-  ///   Defaults to false.
-  ///
-  ///   _Tip: To log only in debug mode, set [verboseLog]'s value to [kReleaseMode]_.
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
     required String fontFamily,
-    @Deprecated(
-      'Use "DynamicCachedFonts.toggleVerboseLogging" instead as it reduces code repetition. '
-      'This feature was deprecated after v0.2.0',
-    )
-        bool verboseLog = false,
-    @visibleForTesting
-        FontLoader? fontLoader,
+    @visibleForTesting FontLoader? fontLoader,
   }) async {
     fontLoader ??= FontLoader(fontFamily);
 
@@ -260,10 +202,7 @@ abstract class RawDynamicCachedFonts {
 
     await fontLoader.load();
 
-    devLog(
-      <String>['Font has been loaded!'],
-      verboseLog: verboseLog,
-    );
+    devLog(<String>['Font has been loaded!']);
 
     return nonNullFontFiles;
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,10 +26,9 @@ const int kDefaultMaxCacheObjects = 200;
 @internal
 void devLog(
   List<String> messageList, {
-  bool verboseLog = false,
   bool? overrideLoggerConfig,
 }) {
-  if (overrideLoggerConfig ?? (Utils.shouldVerboseLog || verboseLog)) {
+  if (overrideLoggerConfig ?? Utils.shouldVerboseLog) {
     final String message = messageList.join('\n');
     dev.log(
       message,
@@ -167,21 +166,15 @@ class Utils {
   /// Checks whether the received [url] is a Cloud Storage url or an https url.
   /// If the url points to a Cloud Storage bucket, then a download url
   /// is generated using the Firebase SDK.
-  static Future<String> handleUrl(
-    String url, {
-    required bool verboseLog,
-  }) async {
+  static Future<String> handleUrl(String url) async {
     final Reference ref = FirebaseStorage.instance.refFromURL(url);
 
-    devLog(
-      <String>[
-        'Created Firebase Storage reference with following values -\n',
-        'Bucket name - ${ref.bucket}',
-        'Object name - ${ref.name}',
-        'Object path - ${ref.fullPath}',
-      ],
-      verboseLog: verboseLog,
-    );
+    devLog(<String>[
+      'Created Firebase Storage reference with following values -\n',
+      'Bucket name - ${ref.bucket}',
+      'Object name - ${ref.name}',
+      'Object path - ${ref.fullPath}',
+    ]);
 
     return ref.getDownloadURL();
   }


### PR DESCRIPTION
- Deprecated in `v0.2.0`
- Replaced by `DynamicCachedFonts.toggleVerboseLogging`

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
