### PR TITLE
De-clutter README by removing unnecessary badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 # Dynamic Cached Fonts
 
-[![GitHub license][license-badge]][license]
 [![Pub Version][pub-version-badge]][pub-package]
 ![Supported Platforms][supported-platforms-badge]
 
 <!-- CI badges -->
-[![Code Analysis][code-analysis-badge]][code-analysis]
-[![Analyze Project][analyze-project-badge]][analyze-project]
-[![Verify Formatting][verify-formatting-badge]][verify-formatting]
-[![Documentation Analysis][doc-analysis-badge]][doc-analysis]
 [![Unit Tests][unit-tests-badge]][unit-tests]
 [![Integration Tests][integration-tests-badge]][integration-tests]
 
@@ -191,25 +186,15 @@ To contribute to the package, fork the repository and open a [pull request]!
 [![Github Stars][github-stars-badge]][github-stars]
 
 <!-- Badges -->
-[license-badge]: https://img.shields.io/github/license/sidrao2006/dynamic_cached_fonts?style=for-the-badge
 [supported-platforms-badge]: https://img.shields.io/badge/Platforms-Android%20%7C%20iOS%20%7C%20Web%20%7C%20Windows%20%7C%20Linux%20%7C%20MacOS-blue?style=for-the-badge
 [pub-version-badge]: https://img.shields.io/pub/v/dynamic_cached_fonts?label=Pub%20%28Latest%20Stable%29&style=for-the-badge
-[code-analysis-badge]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/code_analysis.yml/badge.svg
-[analyze-project-badge]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/analyze_project.yml/badge.svg
-[verify-formatting-badge]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/verify_formatting.yml/badge.svg
-[doc-analysis-badge]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/dartdoc.yml/badge.svg
 [unit-tests-badge]:https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/package_unit_test.yml/badge.svg
 [integration-tests-badge]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/integration_test.yml/badge.svg
 [github-forks-badge]: https://img.shields.io/github/forks/sidrao2006/dynamic_cached_fonts?style=social
 [github-stars-badge]: https://img.shields.io/github/stars/sidrao2006/dynamic_cached_fonts?style=social
 
 <!-- Badge Follow Up Links -->
-[license]: https://github.com/sidrao2006/dynamic_cached_fonts/blob/main/LICENSE
 [pub-package]: https://pub.dev/packages/dynamic_cached_fonts
-[code-analysis]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/code_analysis.yml
-[analyze-project]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/analyze_project.yml
-[verify-formatting]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/verify_formatting.yml
-[doc-analysis]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/dartdoc.yml
 [unit-tests]:https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/package_unit_test.yml
 [integration-tests]: https://github.com/sidrao2006/dynamic_cached_fonts/actions/workflows/integration_test.yml
 [github-forks]: https://github.com/sidrao2006/dynamic_cached_fonts/fork


### PR DESCRIPTION
- Remove selected CI badges
  - Remove 'Code Analysis' badge - Pub calculates and displays this score on pub.dev under 'pub points'
  - Remove 'Analyze Project' badge - Linting is one of the factors which decides the 'pub points' displayed on the package page
  - Remove 'Verify Formatting' badge - Irrelevant to package users
  - Remove 'Documentation Analysis' badge - Documentation is also one of the factors which decides the 'pub points'

- Remove license badge since both, Github and Pub, display the license type

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
