### PR TITLE
Release v0.4.0 - Drop support for `verboseLog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.4.0
+
+**BREAKING CHANGE: `verboseLog`, which was deprecated in v0.2.0, has been removed. `DynamicCachedFonts.toggleVerboseLogging` should be used instead**
+
+> The online demo (i.e, the hosted example app) is now available. Check it out [here][online-demo]!!
+
+[online-demo]: https://sidrao2006.github.io/dynamic_cached_fonts
+
 # 0.3.1
 
 **Dependency Updates**
@@ -16,9 +24,7 @@ Stable Null safety release
 
 **Features/Updates**
 
-- **`verboseLog` is not deprecated in all APIs. `DynamicCachedFonts.toggleVerboseLogging` should be used instead to toggle verbose logging**
-
-> It's likely that support for `verboseLog` will end in v1.0.0.
+- **`verboseLog` is now deprecated in all APIs. `DynamicCachedFonts.toggleVerboseLogging` should be used instead to toggle verbose logging**
 
 - **`loadCachedFont` and `loadCachedFamily` now throws a `StateError` if the font has not been cached**
 - **`UnsupportedError` is thrown if the downloaded file is not a .ttf or .otf font file**
@@ -45,4 +51,4 @@ Stable Null safety release
 
 # 0.0.1
 
-Initial Release (Non null-safe)
+Initial Release

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.4.0"
   fake_async:
     dependency: transitive
     description:
@@ -205,7 +205,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -268,7 +268,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -364,7 +364,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -392,7 +392,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.0"
   webdriver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_cached_fonts
 description: A font loader to download, cache and load web fonts in flutter with support for Firebase Cloud Storage.
-version: 0.3.1
+version: 0.4.0
 repository: https://github.com/sidrao2006/dynamic_cached_fonts
 
 environment:


### PR DESCRIPTION
`DynamicCachedFonts.toggleVerboseLogging` should be used instead

Deprecated in v0.2.0

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

Yes

I have deleted the following public APIs which will break the users' code - 
  1. `verboseLog`