### PR TITLE
Fix invalid object error in release labeler

### DIFF
--- a/dev/ci/labeler.js
+++ b/dev/ci/labeler.js
@@ -37,7 +37,7 @@ exports.addReleaseLabel = async ({
 
     await github.actions.createWorkflowDispatch({
       owner, repo, workflow_id,
-      ref: github.ref,
+      ref: context.ref,
     });
   }
 }


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
