### PR TITLE
Add methods that return a `Stream` of fonts

### DIFF
--- a/example/lib/constants.dart
+++ b/example/lib/constants.dart
@@ -8,6 +8,8 @@ const String firaMono = 'FiraMono';
 const String notoSans = 'NotoSans';
 const String firaCode = 'FiraCode';
 const String firaSans = 'FiraSans';
+const String roboto = 'Roboto';
+const String mononoki = 'Mononoki';
 
 // Font source urls
 
@@ -17,10 +19,23 @@ const String cascadiaCodeUrl =
     'https://cdn.jsdelivr.net/gh/ryanoasis/nerd-fonts@v2.1.0/patched-fonts/CascadiaCode/complete/Caskaydia%20Cove%20Nerd%20Font%20Complete%20Mono.ttf';
 const String firaMonoUrl =
     'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraMono-Regular.ttf';
-
 const String firaSansBoldUrl =
         'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Bold.ttf',
     firaSansRegularUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Regular.ttf',
     firaSansItalicUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Italic.ttf',
     firaSansThinUrl = 'https://cdn.jsdelivr.net/gh/mozilla/Fira@4.202/ttf/FiraSans-Thin.ttf';
+const String robotoRegularUrl =
+        'https://cdn.jsdelivr.net/gh/googlefonts/roboto@v2.138/src/hinted/Roboto-Regular.ttf',
+    robotoThinUrl =
+        'https://cdn.jsdelivr.net/gh/googlefonts/roboto@v2.138/src/hinted/Roboto-Thin.ttf',
+    robotoBoldUrl =
+        'https://cdn.jsdelivr.net/gh/googlefonts/roboto@v2.138/src/hinted/Roboto-Bold.ttf',
+    robotoItalicUrl =
+        'https://cdn.jsdelivr.net/gh/googlefonts/roboto@v2.138/src/hinted/Roboto-Italic.ttf';
+const String mononokiBoldUrl =
+        'https://cdn.jsdelivr.net/gh/madmalik/mononoki@1.3/export/mononoki-Bold.ttf',
+    mononokiRegularUrl =
+        'https://cdn.jsdelivr.net/gh/madmalik/mononoki@1.3/export/mononoki-Regular.ttf',
+    mononokiItalicUrl =
+        'https://cdn.jsdelivr.net/gh/madmalik/mononoki@1.3/export/mononoki-Italic.ttf';
 const String firaCodeUrl = String.fromEnvironment('FIREBASE_STORAGE_FONT_URL');

--- a/example/lib/src/demos/download_use_controls_family_stream_demo.dart
+++ b/example/lib/src/demos/download_use_controls_family_stream_demo.dart
@@ -1,0 +1,155 @@
+import 'package:async/async.dart' show StreamGroup;
+
+import 'package:dynamic_cached_fonts/dynamic_cached_fonts.dart';
+import 'package:dynamic_cached_fonts_example/constants.dart';
+import 'package:flutter/material.dart';
+
+import '../components.dart';
+
+class DynamicCachedFontsDemo7 extends StatefulWidget {
+  const DynamicCachedFontsDemo7({Key? key}) : super(key: key);
+
+  @override
+  _DynamicCachedFontsDemo7State createState() => _DynamicCachedFontsDemo7State();
+}
+
+class _DynamicCachedFontsDemo7State extends State<DynamicCachedFontsDemo7> {
+  int position = 0, total = 0;
+  double progress = 0;
+  DownloadProgress? downloadProgress;
+
+  final List<String> fontUrls = [mononokiBoldUrl, mononokiItalicUrl, mononokiRegularUrl];
+  late final Stream<FileInfo> downloadFontStreams;
+  late final Stream<FileInfo> loadCachedFamilyStream;
+
+  @override
+  void initState() {
+    setupFontLoader();
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('$demoTitle - Load Family As Stream (Custom Controls)'),
+      ),
+      body: Column(
+        children: <Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <CustomButton>[
+              CustomButton(
+                onPressed: handleDownloadButtonPress,
+              ),
+              CustomButton(
+                icon: Icons.font_download,
+                title: 'Use Font',
+                onPressed: handleUseFontPress,
+              ),
+            ],
+          ),
+          DisplayText(
+            'The text is being displayed in the default flutter font which is ${DefaultTextStyle.of(context).style.fontFamily}.',
+            fontFamily: '',
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $mononoki bold, click the download button above ☝️.',
+            fontFamily: mononoki,
+            fontWeight: FontWeight.bold,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $mononoki italic, click the download button above ☝️.',
+            fontFamily: mononoki,
+            fontStyle: FontStyle.italic,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $mononoki, click the download button above ☝️.',
+            fontFamily: mononoki,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          ...showLoaders()
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.startFloat,
+      floatingActionButton: ExtendedButton(
+        icon: Icons.navigate_before,
+        label: 'Previous Example',
+        onPressed: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  Future<void> handleDownloadButtonPress() => downloadFontStreams.listen((_) {}).asFuture();
+
+  Future<void> handleUseFontPress() async {
+    if ((await Future.wait(fontUrls.map(DynamicCachedFonts.canLoadFont)))
+        .every((canLoad) => canLoad = true))
+      loadCachedFamilyStream.listen((_) {});
+    else {
+      print('Font not found in cache :(');
+      // Font is not in cache...download font or do something else.
+
+      // Uncomment the below line to download font is it is not present in cache.
+      // return await DynamicCachedFonts.cacheFont(url);
+    }
+  }
+
+  void setupFontLoader() {
+    downloadFontStreams = StreamGroup.merge(
+      fontUrls.map(
+        (url) => DynamicCachedFonts.cacheFontStream(
+          url,
+          progressListener: (downloadProgress) =>
+              setState(() => this.downloadProgress = downloadProgress),
+        ),
+      ),
+    );
+
+    loadCachedFamilyStream = DynamicCachedFonts.loadCachedFamilyStream(
+      fontUrls,
+      fontFamily: mononoki,
+      progressListener: (progress, totalItems, currentFont) => setState(() {
+        this.progress = progress;
+        total = totalItems;
+        position = currentFont;
+      }),
+    );
+  }
+
+  List<Widget> showLoaders() {
+    final List<Widget> loaders = [];
+
+    if (position != total)
+      loaders.addAll([
+        Text('Downloading font $position of $total...'),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: LinearProgressIndicator(
+            value: progress,
+          ),
+        )
+      ]);
+    else if (position == total && position != 0)
+      loaders.add(Text('Download complete! $total fonts downloaded.'));
+
+    if (downloadProgress != null && downloadProgress!.progress != null)
+      loaders.addAll([
+        Text('Downloading font from ${downloadProgress?.originalUrl}...'),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: LinearProgressIndicator(
+            value: downloadProgress?.progress ?? 0,
+          ),
+        ),
+      ]);
+    else if (downloadProgress != null && downloadProgress!.downloaded > 0)
+      loaders.add(Text('Downloaded font from ${downloadProgress?.originalUrl}!'));
+
+    return loaders;
+  }
+}

--- a/example/lib/src/demos/download_use_family_stream_demo.dart
+++ b/example/lib/src/demos/download_use_family_stream_demo.dart
@@ -1,0 +1,137 @@
+import 'package:dynamic_cached_fonts/dynamic_cached_fonts.dart';
+import 'package:flutter/material.dart';
+import 'package:dynamic_cached_fonts_example/constants.dart';
+
+import '../components.dart';
+import 'download_use_controls_family_stream_demo.dart';
+
+class DynamicCachedFontsDemo6 extends StatefulWidget {
+  const DynamicCachedFontsDemo6({Key? key}) : super(key: key);
+
+  @override
+  _DynamicCachedFontsDemo6State createState() => _DynamicCachedFontsDemo6State();
+}
+
+class _DynamicCachedFontsDemo6State extends State<DynamicCachedFontsDemo6> {
+  int position = 0, total = 0;
+  double progress = 0;
+
+  late final Stream<FileInfo> fontStream;
+  DownloadProgress? downloadProgress;
+
+  @override
+  void initState() {
+    setupFontLoader();
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          '$demoTitle - Load Family As Stream',
+        ),
+      ),
+      body: Column(
+        children: <Widget>[
+          CustomButton(
+            title: 'Download and Use',
+            onPressed: handleDownloadButtonPress,
+          ),
+          DisplayText(
+            'The text is being displayed in the default flutter font which is ${DefaultTextStyle.of(context).style.fontFamily}.',
+            fontFamily: '',
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $roboto bold, click the download button above ☝️.',
+            fontFamily: roboto,
+            fontWeight: FontWeight.bold,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $roboto italic, click the download button above ☝️.',
+            fontFamily: roboto,
+            fontStyle: FontStyle.italic,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $roboto, click the download button above ☝️.',
+            fontFamily: roboto,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          DisplayText(
+            'To download $roboto thin, click the download button above ☝️.',
+            fontFamily: roboto,
+            fontWeight: FontWeight.w100,
+            fontSize: Theme.of(context).textTheme.headline6!.fontSize,
+          ),
+          ...showLoaders(),
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButton: ExtendedButton(
+        icon: Icons.navigate_next,
+        label: 'Next Example',
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute<DynamicCachedFontsDemo7>(
+            builder: (_) => const DynamicCachedFontsDemo7(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void handleDownloadButtonPress() => fontStream.listen((_) {});
+
+  void setupFontLoader() {
+    final DynamicCachedFonts dynamicCachedFont = DynamicCachedFonts.family(
+      fontFamily: roboto,
+      urls: [robotoBoldUrl, robotoItalicUrl, robotoRegularUrl, robotoThinUrl],
+    );
+    fontStream = dynamicCachedFont.loadStream(
+      itemCountProgressListener: (progress, totalItems, currentFont) => setState(() {
+        this.progress = progress;
+        total = totalItems;
+        position = currentFont;
+      }),
+      downloadProgressListener: (downloadProgress) =>
+          setState(() => this.downloadProgress = downloadProgress),
+    );
+  }
+
+  List<Widget> showLoaders() {
+    final List<Widget> loaders = [];
+
+    if (position != total)
+      loaders.addAll([
+        Text('Downloading font $position of $total...'),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: LinearProgressIndicator(
+            value: progress,
+          ),
+        )
+      ]);
+    else if (position == total && position != 0)
+      loaders.add(Text('Download complete! $total fonts downloaded.'));
+
+    if (downloadProgress != null && downloadProgress!.progress != null)
+      loaders.addAll([
+        Text('Downloading font from ${downloadProgress?.originalUrl}...'),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: LinearProgressIndicator(
+            value: downloadProgress?.progress ?? 0,
+          ),
+        ),
+      ]);
+    else if (downloadProgress != null && downloadProgress!.downloaded > 0)
+      loaders.add(Text('Downloaded font from ${downloadProgress?.originalUrl}!'));
+
+    return loaders;
+  }
+}

--- a/example/lib/src/demos/multi_font_loading_demo.dart
+++ b/example/lib/src/demos/multi_font_loading_demo.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:dynamic_cached_fonts_example/constants.dart';
 
 import '../components.dart';
+import 'download_use_family_stream_demo.dart';
 
 class DynamicCachedFontsDemo5 extends StatefulWidget {
   const DynamicCachedFontsDemo5({Key? key}) : super(key: key);
@@ -65,11 +66,16 @@ class _DynamicCachedFontsDemo5State extends State<DynamicCachedFontsDemo5> {
           ),
         ],
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.startFloat,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       floatingActionButton: ExtendedButton(
-        icon: Icons.navigate_before,
-        label: 'Previous Example',
-        onPressed: () => Navigator.pop(context),
+        icon: Icons.navigate_next,
+        label: 'Next Example',
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute<DynamicCachedFontsDemo6>(
+            builder: (_) => const DynamicCachedFontsDemo6(),
+          ),
+        ),
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,9 +7,9 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       url: "https://pub.dartlang.org"
@@ -191,7 +191,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -212,7 +212,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -226,7 +226,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqflite:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -392,14 +392,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.0"
   webdriver:
     dependency: transitive
     description:
@@ -422,5 +422,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=2.5.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   dynamic_cached_fonts:
     path: ../
   firebase_core: ^1.0.1
+  async: ^2.8.2
 
 dev_dependencies:
   flutter_lints: ^1.0.3

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -7,6 +7,26 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:meta/meta.dart';
 
+/// Signature for `itemCountProgressListener` and `progressListener` callbacks 
+/// that return no data and have the following arguments -
+/// 
+/// - The [progress] argument is a double between 0.0 and 1.0, indicating the
+///   fraction of items that have been downloaded.
+/// 
+/// - The [totalItems] argument is the total number of items to be downloaded.
+/// 
+/// - The [downloadedItems] argument is the number of items that have been
+///   downloaded so far.
+typedef ItemCountProgressListener = void Function(
+    double progress, int totalItems, int downloadedItems);
+
+/// Signature for `downloadProgressListener` and `progressListener` callbacks
+/// that return no data and has a single argument -
+/// 
+/// - The [progress] argument is a [DownloadProgress] object that contains
+///   information about the download progress.
+typedef DownloadProgressListener = void Function(DownloadProgress progress);
+
 /// Gets the sanitized url from [url] which is used as `cacheKey` when
 /// downloading, caching or loading.
 @visibleForTesting
@@ -193,4 +213,11 @@ class Utils {
   /// Remove `/` or `:` from url which can cause errors when used as storage paths
   /// in some operating systems.
   static String sanitizeUrl(String url) => url.replaceAll(RegExp(r'\/|:'), '');
+
+  /// Returns the file name of the font or the url if the url cannot be parsed.
+  static String getFileNameOrUrl(String url) {
+    final int index = url.lastIndexOf('/');
+    if (index < 0 || index + 1 >= url.length) return url;
+    return url.substring(index + 1);
+  }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -7,14 +7,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:meta/meta.dart';
 
-/// Signature for `itemCountProgressListener` and `progressListener` callbacks 
+/// Signature for `itemCountProgressListener` and `progressListener` callbacks
 /// that return no data and have the following arguments -
-/// 
+///
 /// - The [progress] argument is a double between 0.0 and 1.0, indicating the
 ///   fraction of items that have been downloaded.
-/// 
+///
 /// - The [totalItems] argument is the total number of items to be downloaded.
-/// 
+///
 /// - The [downloadedItems] argument is the number of items that have been
 ///   downloaded so far.
 typedef ItemCountProgressListener = void Function(
@@ -22,7 +22,7 @@ typedef ItemCountProgressListener = void Function(
 
 /// Signature for `downloadProgressListener` and `progressListener` callbacks
 /// that return no data and has a single argument -
-/// 
+///
 /// - The [progress] argument is a [DownloadProgress] object that contains
 ///   information about the download progress.
 typedef DownloadProgressListener = void Function(DownloadProgress progress);


### PR DESCRIPTION
Adds 3 methods

- `DynamicCachedFonts.loadStream`
- `DynamicCachedFonts.cacheFontStream`/`RawDynamicCachedFonts.cacheFontStream`
- `DynamicCachedFonts.loadCachedFamilyStream`/`RawDynamicCachedFonts.loadCachedFamilyStream`

Thanks to [jjoelj](https://github.com/jjoelj) whose fork inspired me to add `Stream` methods.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
