### PR TITLE
Generate safer cache keys

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -210,9 +210,9 @@ class Utils {
     }
   }
 
-  /// Remove `/` or `:` from url which can cause errors when used as storage paths
-  /// in some operating systems.
-  static String sanitizeUrl(String url) => url.replaceAll(RegExp(r'\/|:'), '');
+  /// Remove reserved characters from url which can cause errors when used as 
+  /// storage paths in some operating systems.
+  static String sanitizeUrl(String url) => url.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '');
 
   /// Returns the file name of the font or the url if the url cannot be parsed.
   static String getFileNameOrUrl(String url) {


### PR DESCRIPTION
Remove all reserved characters from the url when generating a cache key

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
