### PR TITLE
Remove redundant call to `setState` in example

### DIFF
--- a/example/lib/src/demos/download_use_delete_demo.dart
+++ b/example/lib/src/demos/download_use_delete_demo.dart
@@ -65,7 +65,6 @@ class _DynamicCachedFontsDemo3State extends State<DynamicCachedFontsDemo3> {
   Future<void> handleUseFontPress() async {
     if (await DynamicCachedFonts.canLoadFont(notoSansUrl)) {
       await DynamicCachedFonts.loadCachedFont(notoSansUrl, fontFamily: notoSans);
-      setState(() {});
     } else {
       print('Font not found in cache :(');
       // Font is not in cache...download font or do something else.


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
