### PR TITLE
Update workflows to fix test-waiter job name error

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       dir: example
       environment: Example Github Pages
+      job_name: Build and Deploy Example to Github Pages # same as jobs.<job_id>.name
     secrets:
       args: --dart-define FIREBASE_STORAGE_FONT_URL=${{ secrets.FIREBASE_STORAGE_FONT_URL }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     uses: sidrao2006/workflows/.github/workflows/pub_release.yml@v1
     with:
       environment: Release
+      job_name: Release and Publish Package # same as jobs.<job_id>.name
     secrets:
       PUB_CREDENTIALS_ACCESS_TOKEN: ${{ secrets.PUB_CREDENTIALS_ACCESS_TOKEN }}
       PUB_CREDENTIALS_REFRESH_TOKEN: ${{ secrets.PUB_CREDENTIALS_REFRESH_TOKEN }}


### PR DESCRIPTION
Affected workflows:
  - gh_pages_deploy
  - release

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
