### PR TITLE
Use unit tests for `removeCachedFont` instead of integration tests

### DIFF
--- a/example/integration_test/dynamic_cached_fonts_example_test.dart
+++ b/example/integration_test/dynamic_cached_fonts_example_test.dart
@@ -526,17 +526,6 @@ void main() {
       expect(progressListener.last, orderedEquals([1.0, fontUrls.length, fontUrls.length]));
     });
   });
-
-  testWidgets('DynamicCachedFonts.removeCachedFont should remove the font from cache', (_) async {
-    await cacheManager.downloadFile(fontUrl, key: cacheKey);
-
-    await DynamicCachedFonts.removeCachedFont(fontUrl);
-
-    await expectLater(
-      cacheManager.getFileFromCache(cacheKey, ignoreMemCache: true),
-      completion(isNull),
-    );
-  });
 }
 
 // Helpers

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
   flutter_lints: ^1.0.3
   flutter_test:
     sdk: flutter
+  mockito: ^5.1.0
 
 false_secrets:
   - /example/android/app/google-services.json

--- a/test/dynamic_cached_fonts_test.dart
+++ b/test/dynamic_cached_fonts_test.dart
@@ -1,6 +1,10 @@
 import 'package:dynamic_cached_fonts/dynamic_cached_fonts.dart';
 import 'package:dynamic_cached_fonts/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:flutter_cache_manager/src/cache_store.dart';
+
+import 'dynamic_cached_fonts_test.mocks.dart';
 
 void main() {
   const String cacheKey = 'DynamicCachedFontsTest';
@@ -161,5 +165,16 @@ void main() {
     ];
 
     expect(mockUrls.map(Utils.getFileNameOrUrl), orderedEquals(expectedFileNames));
+  });
+
+  test('DynamicCachedFonts.removeCachedFont should remove the font from cache', () async {
+    final cacheManager = MockCacheManager();
+    when(cacheManager.store).thenReturn(CacheStore(Config(cacheKey)));
+
+    DynamicCachedFonts.custom(cacheManager: cacheManager);
+
+    await DynamicCachedFonts.removeCachedFont(mockUrl);
+
+    verify(cacheManager.removeFile(cacheKeyFromUrl(mockUrl))).called(1);
   });
 }

--- a/test/dynamic_cached_fonts_test.mocks.dart
+++ b/test/dynamic_cached_fonts_test.mocks.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/src/cache_store.dart';
+import 'package:mockito/mockito.dart';
+
+class _FakeCacheStore extends Fake implements CacheStore {}
+
+/// A class which mocks [CacheManager].
+class MockCacheManager extends Mock implements CacheManager {
+  @override
+  CacheStore get store =>
+      super.noSuchMethod(Invocation.getter(#store), returnValue: _FakeCacheStore()) as CacheStore;
+
+  @override
+  Future<void> removeFile(String? key) async =>
+      super.noSuchMethod(Invocation.method(#removeFile, [key]));
+}


### PR DESCRIPTION
- Integration tests for `removeCachedFont` were extremely flaky on iOS and Android

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
