### PR TITLE
Improve testability by adding `DynamicCachedFontsCacheManager.unsetCustomCacheManager`

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -109,6 +109,13 @@ class DynamicCachedFontsCacheManager {
     _cacheManagers[_customCacheKey!] = cacheManager;
   }
 
+  @visibleForTesting
+  /// Unsets the custom instance of [CacheManager] in [_cacheManagers].
+  static unsetCustomCacheManager() {
+    _cacheManagers.remove(_customCacheKey);
+    _customCacheKey = null;
+  }
+
   /// Returns a custom [CacheManager], if present, or
   static CacheManager getCacheManager(String cacheKey) =>
       getCustomCacheManager() ?? _cacheManagers[cacheKey] ?? defaultCacheManager;

--- a/test/dynamic_cached_fonts_test.dart
+++ b/test/dynamic_cached_fonts_test.dart
@@ -19,6 +19,8 @@ void main() {
     'https://example.com/fontTest7.ttf#test?v=1',
   ];
 
+  tearDown(() => DynamicCachedFontsCacheManager.unsetCustomCacheManager());
+
   test('Default constructor applies default values', () {
     final DynamicCachedFonts fontLoader =
         DynamicCachedFonts(url: mockUrl, fontFamily: mockFontFamily);
@@ -70,14 +72,13 @@ void main() {
     });
 
     test('does not replace the cache manager if force is false', () {
+      final CacheManager cacheManager = CacheManager(Config(cacheKey));
       final CacheManager newCacheManager = CacheManager(Config('$cacheKey-new'));
 
+      DynamicCachedFonts.custom(cacheManager: cacheManager);
       DynamicCachedFonts.custom(cacheManager: newCacheManager);
 
-      expect(
-        DynamicCachedFontsCacheManager.getCustomCacheManager(),
-        isNot(equals(newCacheManager)),
-      );
+      expect(DynamicCachedFontsCacheManager.getCustomCacheManager(), equals(cacheManager));
     });
 
     test('replaces the cache manager if force is true', () {


### PR DESCRIPTION
Update tests to make use of the changes.

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
