### PR TITLE
Fix failing integration tests

### DIFF
--- a/example/integration_test/dynamic_cached_fonts_example_test.dart
+++ b/example/integration_test/dynamic_cached_fonts_example_test.dart
@@ -94,7 +94,7 @@ void main() {
 
       final Stream<String> fontFileNameStream = fontStream.map((font) => font.file.basename);
 
-      await expectLater(fontFileNameStream, emitsThrough(endsWith('ttf')));
+      await expectLater(fontFileNameStream, emitsInOrder(List.generate(4, (e) => endsWith('ttf'))));
     });
 
     testWidgets('should allow font to be loaded only once', (_) async {
@@ -142,7 +142,7 @@ void main() {
         progressListener,
         anyElement(
           predicate<DownloadProgress>(
-            (progress) => progress.progress != null && progress.progress! > 0,
+            (progress) => progress.downloaded > 0,
             'has a progress value greater than 0',
           ),
         ),
@@ -332,7 +332,7 @@ void main() {
         progressListener,
         anyElement(
           predicate<DownloadProgress>(
-            (progress) => progress.progress != null && progress.progress! > 0,
+            (progress) => progress.downloaded > 0,
             'has a progress value greater than 0',
           ),
         ),
@@ -479,7 +479,7 @@ void main() {
     testWidgets('should load font files with a valid extension', (_) async {
       final Stream<String> fontFileNameStream = fontStream.map((font) => font.file.basename);
 
-      await expectLater(fontFileNameStream, emitsThrough(endsWith('ttf')));
+      await expectLater(fontFileNameStream, emitsInOrder(List.generate(4, (e) => endsWith('ttf'))));
     });
 
     testWidgets('should load valid font files', (_) async {


### PR DESCRIPTION
1. Check `downloaded` instead of `progress`, as the later can return null and cause the test to be flaky
Affected tests

- 'DynamicCachedFonts.loadStream', 'DynamicCachedFonts.cacheFontStream' + 'should emit downloadProgress events'

2. Use `emitsInOrder` instead of `emitsThrough` to force the test to end only after the stream is complete
Affected tests

-  'DynamicCachedFonts.loadStream', 'DynamicCachedFonts.loadCachedFamilyStream' + 'should load font file with a valid extension'

-> Fixes flaky integration tests on desktop

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
