### PR TITLE
Release v1.1.0 - Update dependency constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.1.0
+
+**Dependency Updates**
+
+- Added support for v11.x of `firebase_storage`. Minimum supported version continues to be v8.0.0
+- Added support for the v3.x of dart sdk. Minimum supported version continues to be v2.12.0
+
+**Internal Updates**
+
+- Add `DynamicCachedFontsCacheManager.unsetCustomCacheManager` method to unset custom cache managers used for testing
+
 # 1.0.0
 
 **Features/Updates**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_cached_fonts
 description: A font loader to download, cache and load web fonts in flutter with support for Firebase Cloud Storage.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/sidrao2006/dynamic_cached_fonts
 
 environment:


### PR DESCRIPTION
**Dependency Updates**

- Added support for v11.x of `firebase_storage`. Minimum supported version continues to be v8.0.0
- Added support for the v3.x of dart sdk. Minimum supported version continues to be v2.12.0

**Internal Updates**

- Add `DynamicCachedFontsCacheManager.unsetCustomCacheManager` method to unset custom cache managers used for testing

## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

No
<!--
If you have made a breaking change, uncomment the line below and fill in the necessary details.

I have modified or deleted the following public APIs which will break the users' code - 
  1. ...
  2. ...
  3. ...
-->
