### PR TITLE
Fix cache config bug

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,8 @@ void main() {
       darkTheme: ThemeData.dark(),
     ),
   );
+
+  DynamicCachedFonts.runMigrationTool();
 }
 
 class DynamicCachedFontsDemo1 extends StatefulWidget {

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -622,7 +622,7 @@ class DynamicCachedFonts {
   /// is required to be run only once but multiple executions will have no side
   /// effects. An empty folder named 'DynamicCachedFontsFontCacheKey' will be
   /// present in the cache folder after running this tool.
-  /// 
+  ///
   /// Sample Usage: Users may add this to the next version of their app and
   /// remove it in the next version. The purpose is to ensure atleast 1 execution
   /// of the tool. Subsequent runs will be useless.

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -263,6 +263,8 @@ class DynamicCachedFonts {
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
       );
 
       // Checks whether any of the files is invalid.
@@ -290,6 +292,8 @@ class DynamicCachedFonts {
       fontFiles = await loadCachedFamily(
         downloadUrls,
         fontFamily: fontFamily,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
       );
     }
 
@@ -333,6 +337,8 @@ class DynamicCachedFonts {
       downloadUrls,
       fontFamily: fontFamily,
       progressListener: itemCountProgressListener,
+      maxCacheObjects: maxCacheObjects,
+      cacheStalePeriod: cacheStalePeriod,
     );
 
     try {
@@ -373,6 +379,8 @@ class DynamicCachedFonts {
         downloadUrls,
         fontFamily: fontFamily,
         progressListener: itemCountProgressListener,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
       );
     }
   }
@@ -488,7 +496,20 @@ class DynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  static Future<bool> canLoadFont(String url) => RawDynamicCachedFonts.canLoadFont(url);
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
+  static Future<bool> canLoadFont(
+    String url, {
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
+  }) =>
+      RawDynamicCachedFonts.canLoadFont(
+        url,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
+      );
 
   /// Fetches the given [url] from cache and loads it as an asset.
   ///
@@ -498,14 +519,22 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
   static Future<FileInfo> loadCachedFont(
     String url, {
     required String fontFamily,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFont(
         url,
         fontFamily: fontFamily,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
         fontLoader: fontLoader,
       );
 
@@ -525,14 +554,22 @@ class DynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
     required String fontFamily,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFamily(
         urls,
         fontFamily: fontFamily,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
         fontLoader: fontLoader,
       );
 
@@ -569,12 +606,16 @@ class DynamicCachedFonts {
     List<String> urls, {
     required String fontFamily,
     ItemCountProgressListener? progressListener,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) =>
       RawDynamicCachedFonts.loadCachedFamilyStream(
         urls,
         fontFamily: fontFamily,
         progressListener: progressListener,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
         fontLoader: fontLoader,
       );
 
@@ -583,8 +624,19 @@ class DynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  static Future<void> removeCachedFont(String url) => RawDynamicCachedFonts.removeCachedFont(
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
+  static Future<void> removeCachedFont(
+    String url, {
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
+  }) =>
+      RawDynamicCachedFonts.removeCachedFont(
         url,
+        maxCacheObjects: maxCacheObjects,
+        cacheStalePeriod: cacheStalePeriod,
       );
 
   /// Used to specify whether detailed logs should be printed for debugging.

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -610,5 +610,21 @@ class DynamicCachedFonts {
     );
   }
 
+  /// ### MIGRATION TOOL FOR v2
+  ///
+  /// Deletes any cache files downloaded using the default cache manager.
+  /// v2 creates separate folders for each font file.
+  ///
+  /// **WARNING: Any fonts downloaded using v1 of this package ( without a custom
+  /// `cacheStalePeriod` or `maxCacheObjects` ) will be deleted.**
+  ///
+  /// Can be placed before or after other [DynamicCachedFonts] methods. The tool
+  /// is required to be run only once but multiple executions will have no side
+  /// effects. An empty folder named 'DynamicCachedFontsFontCacheKey' will be
+  /// present in the cache folder after running this tool.
+  /// 
+  /// Sample Usage: Users may add this to the next version of their app and
+  /// remove it in the next version. The purpose is to ensure atleast 1 execution
+  /// of the tool. Subsequent runs will be useless.
   static Future<void> runMigrationTool() => migrationTool();
 }

--- a/lib/dynamic_cached_fonts.dart
+++ b/lib/dynamic_cached_fonts.dart
@@ -609,4 +609,6 @@ class DynamicCachedFonts {
       overrideLoggerConfig: true,
     );
   }
+
+  static Future<void> runMigrationTool() => migrationTool();
 }

--- a/lib/src/raw_dynamic_cached_fonts.dart
+++ b/lib/src/raw_dynamic_cached_fonts.dart
@@ -68,10 +68,11 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
-
-    final FileInfo font =
-        await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).downloadFile(
+    final FileInfo font = await DynamicCachedFontsCacheManager.getCacheManager(
+      cacheKey,
+      cacheStalePeriod,
+      maxCacheObjects,
+    ).downloadFile(
       url,
       key: cacheKey,
     );
@@ -127,10 +128,11 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, cacheStalePeriod, maxCacheObjects);
-
-    final Stream<FileResponse> stream =
-        DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileStream(
+    final Stream<FileResponse> stream = DynamicCachedFontsCacheManager.getCacheManager(
+      cacheKey,
+      cacheStalePeriod,
+      maxCacheObjects,
+    ).getFileStream(
       url,
       key: cacheKey,
       withProgress: progressListener != null,
@@ -164,13 +166,24 @@ abstract class RawDynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  static Future<bool> canLoadFont(String url) async {
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
+  static Future<bool> canLoadFont(
+    String url, {
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
+  }) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final FileInfo? font =
-        await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+    final FileInfo? font = await DynamicCachedFontsCacheManager.getCacheManager(
+      cacheKey,
+      cacheStalePeriod,
+      maxCacheObjects,
+    ).getFileFromCache(cacheKey);
 
     return font != null;
   }
@@ -189,6 +202,8 @@ abstract class RawDynamicCachedFonts {
   static Future<FileInfo> loadCachedFont(
     String url, {
     required String fontFamily,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) async {
     fontLoader ??= FontLoader(fontFamily);
@@ -197,8 +212,11 @@ abstract class RawDynamicCachedFonts {
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    final FileInfo? font =
-        await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+    final FileInfo? font = await DynamicCachedFontsCacheManager.getCacheManager(
+      cacheKey,
+      cacheStalePeriod,
+      maxCacheObjects,
+    ).getFileFromCache(cacheKey);
 
     if (font == null) {
       throw StateError('Font should already be cached to be loaded');
@@ -239,9 +257,15 @@ abstract class RawDynamicCachedFonts {
   ///
   /// - **REQUIRED** The [fontFamily] property is used to specify the name
   ///   of the font family which is to be used as [TextStyle.fontFamily].
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
   static Future<Iterable<FileInfo>> loadCachedFamily(
     List<String> urls, {
     required String fontFamily,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) async {
     fontLoader ??= FontLoader(fontFamily);
@@ -252,8 +276,11 @@ abstract class RawDynamicCachedFonts {
     for (final String url in urls) {
       final String cacheKey = Utils.sanitizeUrl(url);
 
-      final FileInfo? font =
-          await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+      final FileInfo? font = await DynamicCachedFontsCacheManager.getCacheManager(
+        cacheKey,
+        cacheStalePeriod,
+        maxCacheObjects,
+      ).getFileFromCache(cacheKey);
 
       if (font == null) {
         throw StateError('Font should already be cached to be loaded');
@@ -304,10 +331,16 @@ abstract class RawDynamicCachedFonts {
   ///   an [int] value which indicates the total number of items to be downloaded and,
   ///   another [int] value which indicates the number of items that have been
   ///   downloaded so far.
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
   static Stream<FileInfo> loadCachedFamilyStream(
     List<String> urls, {
     required String fontFamily,
     required ItemCountProgressListener? progressListener,
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
     @visibleForTesting FontLoader? fontLoader,
   }) async* {
     fontLoader ??= FontLoader(fontFamily);
@@ -317,8 +350,11 @@ abstract class RawDynamicCachedFonts {
     for (final String url in urls) {
       final String cacheKey = Utils.sanitizeUrl(url);
 
-      final FileInfo? font =
-          await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).getFileFromCache(cacheKey);
+      final FileInfo? font = await DynamicCachedFontsCacheManager.getCacheManager(
+        cacheKey,
+        cacheStalePeriod,
+        maxCacheObjects,
+      ).getFileFromCache(cacheKey);
 
       if (font == null) {
         throw StateError('Font should already be cached to be loaded');
@@ -357,11 +393,23 @@ abstract class RawDynamicCachedFonts {
   /// - **REQUIRED** The [url] property is used to specify the url
   ///   for the required font. It should be a valid http/https url which points to
   ///   a font file. The [url] should match the url passed to [cacheFont].
-  static Future<void> removeCachedFont(String url) async {
+  ///
+  /// - The [maxCacheObjects] property should match the value passed to [cacheFont].
+  ///
+  /// - The [cacheStalePeriod] property should match the value passed to [cacheFont].
+  static Future<void> removeCachedFont(
+    String url, {
+    int maxCacheObjects = kDefaultMaxCacheObjects,
+    Duration cacheStalePeriod = kDefaultCacheStalePeriod,
+  }) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     final String cacheKey = Utils.sanitizeUrl(url);
 
-    await DynamicCachedFontsCacheManager.getCacheManager(cacheKey).removeFile(cacheKey);
+    await DynamicCachedFontsCacheManager.getCacheManager(
+      cacheKey,
+      cacheStalePeriod,
+      maxCacheObjects,
+    ).removeFile(cacheKey);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -28,15 +28,13 @@ typedef DownloadProgressListener = void Function(DownloadProgress progress);
 
 /// ### MIGRATION TOOL FOR v2
 ///
-/// Deletes any cache files downloaded using the default cache manager. 
+/// Deletes any cache files downloaded using the default cache manager.
 ///
 /// **WARNING: Any fonts downloaded using v1 of this package ( without a custom
 /// `cacheStalePeriod` or `maxCacheObjects` ) will be deleted.**
 ///
 /// v2 creates separate folders for each font file.
-void migrationTool() => CacheManager(Config('DynamicCachedFontsFontCacheKey'))
-  ..emptyCache()
-  ..dispose();
+Future<void> migrationTool() => CacheManager(Config('DynamicCachedFontsFontCacheKey')).emptyCache();
 
 /// Gets the sanitized url from [url] which is used as `cacheKey` when
 /// downloading, caching or loading.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -105,21 +105,22 @@ class DynamicCachedFontsCacheManager {
 
   /// Returns a custom [CacheManager], if present, or create, add to [_cacheManagers]
   /// and return a new instance of [CacheManager] with [cacheKey] as [Config.cacheKey].
-  static CacheManager getCacheManager(String cacheKey) {
-    final cacheManager = _cacheManagers.putIfAbsent(cacheKey, () => CacheManager(Config(cacheKey)));
+  static CacheManager getCacheManager(
+    String cacheKey,
+    Duration cacheStalePeriod,
+    int maxCacheObjects,
+  ) {
+    final cacheManager = _cacheManagers.putIfAbsent(
+      cacheKey,
+      () => CacheManager(Config(
+        cacheKey,
+        stalePeriod: cacheStalePeriod,
+        maxNrOfCacheObjects: maxCacheObjects,
+      )),
+    );
 
     return getCustomCacheManager() ?? cacheManager;
   }
-
-  /// Creates a new instance of [CacheManager] with the given configuration.
-  static void handleCacheManager(String cacheKey, Duration cacheStalePeriod, int maxCacheObjects) =>
-      _cacheManagers[cacheKey] ??= CacheManager(
-        Config(
-          cacheKey,
-          stalePeriod: cacheStalePeriod,
-          maxNrOfCacheObjects: maxCacheObjects,
-        ),
-      );
 
   /// Clears the list of the [CacheManager]s.
   @visibleForTesting

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,6 +26,18 @@ typedef ItemCountProgressListener = void Function(
 ///   information about the download progress.
 typedef DownloadProgressListener = void Function(DownloadProgress progress);
 
+/// ### MIGRATION TOOL FOR v2
+///
+/// Deletes any cache files downloaded using the default cache manager. 
+///
+/// **WARNING: Any fonts downloaded using v1 of this package ( without a custom
+/// `cacheStalePeriod` or `maxCacheObjects` ) will be deleted.**
+///
+/// v2 creates separate folders for each font file.
+void migrationTool() => CacheManager(Config('DynamicCachedFontsFontCacheKey'))
+  ..emptyCache()
+  ..dispose();
+
 /// Gets the sanitized url from [url] which is used as `cacheKey` when
 /// downloading, caching or loading.
 @visibleForTesting

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,14 +26,8 @@ typedef ItemCountProgressListener = void Function(
 ///   information about the download progress.
 typedef DownloadProgressListener = void Function(DownloadProgress progress);
 
-/// ### MIGRATION TOOL FOR v2
-///
+/// Migratoin tool for v2
 /// Deletes any cache files downloaded using the default cache manager.
-///
-/// **WARNING: Any fonts downloaded using v1 of this package ( without a custom
-/// `cacheStalePeriod` or `maxCacheObjects` ) will be deleted.**
-///
-/// v2 creates separate folders for each font file.
 Future<void> migrationTool() => CacheManager(Config('DynamicCachedFontsFontCacheKey')).emptyCache();
 
 /// Gets the sanitized url from [url] which is used as `cacheKey` when

--- a/test/dynamic_cached_fonts_test.dart
+++ b/test/dynamic_cached_fonts_test.dart
@@ -116,27 +116,30 @@ void main() {
   group('DynamicCachedFontsCacheManager', () {
     setUp(() => DynamicCachedFontsCacheManager.clearCacheManagers());
 
-    test('uses the correct cache key for the default instance', () {
-      const String defaultCacheKey = 'DynamicCachedFontsFontCacheKey';
-      final CacheManager defaultCacheManager = DynamicCachedFontsCacheManager.defaultCacheManager;
-
-      expect(defaultCacheManager.store.storeKey, equals(defaultCacheKey));
-    });
-
-    test('getCacheManager returns the default cache manager', () {
-      final cacheManager = DynamicCachedFontsCacheManager.getCacheManager(cacheKey);
-
-      expect(cacheManager, equals(DynamicCachedFontsCacheManager.defaultCacheManager));
-    });
-
-    test('handleCacheManager creates a new instance for non-default values', () {
-      // A new instance of CacheManager is created only if the default values aren't used.
-      DynamicCachedFontsCacheManager.handleCacheManager(cacheKey, const Duration(days: 366), 201);
-
-      final cacheManager = DynamicCachedFontsCacheManager.getCacheManager(cacheKey);
+    test('getCacheManager returns a cache manager which uses cacheKey', () {
+      final cacheManager = DynamicCachedFontsCacheManager.getCacheManager(
+        cacheKey,
+        kDefaultCacheStalePeriod,
+        kDefaultMaxCacheObjects,
+      );
 
       expect(cacheManager.store.storeKey, equals(cacheKey));
-      expect(cacheManager, isNot(equals(DynamicCachedFontsCacheManager.defaultCacheManager)));
+    });
+
+    test('getCacheManager prioritizes first-defined configuration values', () {
+      final defaultCacheManager = DynamicCachedFontsCacheManager.getCacheManager(
+        cacheKey,
+        kDefaultCacheStalePeriod,
+        kDefaultMaxCacheObjects,
+      );
+
+      final cacheManager = DynamicCachedFontsCacheManager.getCacheManager(
+        cacheKey,
+        kDefaultCacheStalePeriod + const Duration(hours: 1),
+        kDefaultMaxCacheObjects + 1,
+      );
+
+      expect(cacheManager, equals(defaultCacheManager));
     });
 
     test('custom cache managers can be set and retrieved', () {
@@ -152,7 +155,14 @@ void main() {
       final CacheManager cacheManager = CacheManager(Config(cacheKey));
       DynamicCachedFontsCacheManager.setCustomCacheManager(cacheManager);
 
-      expect(DynamicCachedFontsCacheManager.getCacheManager(cacheKey), equals(cacheManager));
+      expect(
+        DynamicCachedFontsCacheManager.getCacheManager(
+          cacheKey,
+          kDefaultCacheStalePeriod,
+          kDefaultMaxCacheObjects,
+        ),
+        equals(cacheManager),
+      );
     });
   });
 


### PR DESCRIPTION
## Breaking Changes and Migration Guide

1. If you have been using the package without modifying `cacheStalePeriod` or `maxCacheObjects`, no changes are required.
However, any previously cached font files will be ignored and should be deleted by running the migration tool.

2. If you have modified `cacheStalePeriod` or `maxCacheObjects`, you'll have to pass the same values to any method that downloads, caches or loads fonts, otherwise the **provided configuration will be ignored.**
Any previously cached font files will continue to remain in their respective cache folders and will be used by the package.
Running the migration tool will have no effect on these font files.

3. A migration tool has been provided -> `DynamicCachedFonts.runMigrationTool()`

---

Original behaviour: A default cache manager with cache key 'DynamicCachedFontsFontCacheKey' was used which stored font files in a folder with the same name.
If a value for `cacheStalePeriod` or `maxCacheObjects` is provided which differs from the default value then a new instance of `CacheManager` would be created with the generated `cacheKey`.

Problems:

1. Once a garbage collection event is run, `_cacheManagers`  is destroyed and hence the package forgets about the modified `CacheManager` and attempts to locate the file in the default cache folder (as mentioned above).

5. `CacheManager` requires a singleton approach. Since each `cacheKey` requires a unique instance of `CacheManager`, calling any method provided by the package before calling `cacheFont`/`cacheFontStream` would result in `cacheStalePeriod`, `maxCacheObjects` to be ignored when downloading and adding the font to cache.

Solutions: 

1. There will be no default instance of `CacheManager`, instead an instance will be created using `cacheKey` after any garbage collection events (which includes app restarts). 

2. Any method that downloads, caches or loads font will now accept `cacheStalePeriod`, `maxCacheObjects` . This ensures that an instance of `CacheManager` will be created only once with the provided config

Changes:

- Require `cacheStalePeriod`, `maxCacheObjects` to be passed to any
method that calls `getCacheManager`. As a result, if the above mentioned
properties are modified by the user of the package at any point, the
modified values should be passed to any method provided by this package
- Require `cacheStalePeriod`, `maxCacheObjects` to be passed to `getCacheManager`
- Remove `handleCacheManager`

See https://github.com/sidrao2006/dynamic_cached_fonts/issues/233