### PR TITLE
Release v2.0.0-dev.0 - Fix cache config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2.0.0-dev.0
+
+## Breaking Changes and Migration Guide
+
+1. If you have been using the package without modifying `cacheStalePeriod` or `maxCacheObjects`, no changes are required.
+However, any previously cached font files will be ignored and should be deleted by running the migration tool.
+
+2. If you have modified `cacheStalePeriod` or `maxCacheObjects`, you'll have to pass the same values to any method that downloads, caches or loads fonts, otherwise the **provided configuration will be ignored.**
+Any previously cached font files will continue to remain in their respective cache folders and will be used by the package.
+Running the migration tool will have no effect on these font files.
+
+3. A migration tool has been provided -> `DynamicCachedFonts.runMigrationTool()`
+
+For more details, see [#247](https://github.com/sidrao2006/dynamic_cached_fonts/pull/247)
+
 # 1.2.0
 
 **Dependency Updates**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "2.0.0-dev.0"
   fake_async:
     dependency: transitive
     description:
@@ -210,18 +210,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -250,18 +250,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -439,10 +439,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_cached_fonts
 description: A font loader to download, cache and load web fonts in flutter with support for Firebase Cloud Storage.
-version: 1.2.0
+version: 2.0.0-dev.0
 repository: https://github.com/sidrao2006/dynamic_cached_fonts
 
 environment:


### PR DESCRIPTION
## Breaking Changes and Migration Guide

1. If you have been using the package without modifying `cacheStalePeriod` or `maxCacheObjects`, no changes are required.
However, any previously cached font files will be ignored and should be deleted by running the migration tool.

2. If you have modified `cacheStalePeriod` or `maxCacheObjects`, you'll have to pass the same values to any method that downloads, caches or loads fonts, otherwise the **provided configuration will be ignored.**
Any previously cached font files will continue to remain in their respective cache folders and will be used by the package.
Running the migration tool will have no effect on these font files.

3. A migration tool has been provided -> `DynamicCachedFonts.runMigrationTool()`

For more details, see [#247](https://github.com/sidrao2006/dynamic_cached_fonts/pull/247)